### PR TITLE
- simplified memory mapping, modified gary to output the full 24-bit …

### DIFF
--- a/Minimig.qsf
+++ b/Minimig.qsf
@@ -29,7 +29,7 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSEBA6U23I7
 set_global_assignment -name TOP_LEVEL_ENTITY sys_top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 16.1.2
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "18.1.0 Lite Edition"
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "01:53:30  APRIL 20, 2017"
 set_global_assignment -name DEVICE_FILTER_PACKAGE UFBGA
 set_global_assignment -name DEVICE_FILTER_PIN_COUNT 672

--- a/src/Minimig_MiSTer.sv
+++ b/src/Minimig_MiSTer.sv
@@ -152,18 +152,18 @@ wire           cache_inhibit;
 wire [ 32-1:0] tg68_cad;
 wire [  6-1:0] tg68_cpustate;
 wire           tg68_nrst_out;
-wire           tg68_cdma;
+// wire           tg68_cdma;
 wire           tg68_clds;
 wire           tg68_cuds;
 wire [  4-1:0] tg68_CACR_out;
 wire [ 32-1:0] tg68_VBR_out;
-wire           tg68_ovr;
+//wire           tg68_ovr;
 
 // minimig
 wire [ 16-1:0] ram_data;      // sram data bus
 wire [ 16-1:0] ramdata_in;    // sram data bus in
 wire [ 48-1:0] chip48;        // big chip read
-wire [ 22-1:1] ram_address;   // sram address bus
+wire [ 24-1:1] ram_address;   // sram address bus
 wire           _ram_bhe;      // sram upper byte select
 wire           _ram_ble;      // sram lower byte select
 wire           _ram_we;       // sram write enable
@@ -263,10 +263,10 @@ TG68K tg68k
 	.turbokick    (turbokick        ),
 	.cache_inhibit(cache_inhibit    ),
 	.fastramcfg   ({&memcfg[5:4],memcfg[5:4]}),
-	.ovr          (tg68_ovr         ),
+//	.ovr          (tg68_ovr         ), 
 	.ramaddr      (tg68_cad         ),
 	.nResetOut    (tg68_nrst_out    ),
-	.cpuDMA       (tg68_cdma        ),
+//	.cpuDMA       (tg68_cdma        ), 
 	.ramlds       (tg68_clds        ),
 	.ramuds       (tg68_cuds        ),
 
@@ -301,7 +301,7 @@ sdram_ctrl sdram
 	.cpuU         (tg68_cuds        ),
 	.cpuL         (tg68_clds        ),
 	.cpustate     (tg68_cpustate    ),
-	.cpu_dma      (tg68_cdma        ),
+//	.cpu_dma      (tg68_cdma        ),
 	.cpuRD        (tg68_cout        ),
 	.cpuena       (tg68_cpuena      ),
 	.enaWRreg     (tg68_enaWR       ),
@@ -309,7 +309,7 @@ sdram_ctrl sdram
 	.ena7WRreg    (tg68_ena7WR      ),
 
 	.chipWR       (ram_data         ),
-	.chipAddr     ({2'b00, ram_address[21:1]}),
+	.chipAddr     (ram_address      ),
 	.chipU        (_ram_bhe         ),
 	.chipL        (_ram_ble         ),
 	.chipRW       (_ram_we          ),
@@ -376,12 +376,12 @@ minimig minimig
 	._cpu_reset   (tg68_rst         ), // M68K reset
 	._cpu_reset_in(tg68_nrst_out    ), // M68K reset out
 	.cpu_vbr      (tg68_VBR_out     ), // M68K VBR
-	.ovr          (tg68_ovr         ), // NMI override address decoding
+//	.ovr          (tg68_ovr         ), // NMI override address decoding
 
 	//sram pins
 	.ram_data     (ram_data         ), // SRAM data bus
 	.ramdata_in   (ramdata_in       ), // SRAM data bus in
-	.ram_address  (ram_address[21:1]), // SRAM address bus
+	.ram_address  (ram_address[23:1]), // SRAM address bus
 	._ram_bhe     (_ram_bhe         ), // SRAM upper byte select
 	._ram_ble     (_ram_ble         ), // SRAM lower byte select
 	._ram_we      (_ram_we          ), // SRAM write enable

--- a/src/cart.v
+++ b/src/cart.v
@@ -22,11 +22,11 @@
 // This is Cart module with support for HRTmon monitor.                       //
 // This module is based on existing ActionReplay.v module by Jakub Bednarski  //
 // and code from WinUAE ar.cpp file. The module requires the ctrl firmware    //
-// to load the special hrtmon.rom file to address 0xa00000. The module        //
-// requires one 512KB RAM bank. The start address (entry point) is 0xa0000c.  //
+// to load the special hrtmon.rom file to address 0xa10000. The module        //
+// requires one 512KB RAM bank. The start address (entry point) is 0xa1000c.  //
 // TODO : custom registers and CIA registers shadow implemented as in WinUAE. //
-// TODO : for better compatibility, load the monitor to $A10000               //
-// (requires recompilation!).                                                 //
+//                                                                            //
+//                                                                            //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
@@ -113,8 +113,8 @@ end
 //assign ovr = active && ~dbr && ~ovl && cpu_rd && (cpu_address_in[23:2]==22'b0000_0000_0000_0000_0111_11);
 assign ovr = active && ~dbr && ~ovl && cpu_rd && (cpu_address_in[23:2] == nmi_vec_adr[23:2]);
 
-// custom NMI vector address output
-assign nmi_adr_out = ovr ? (!cpu_address_in[1] ? 16'h00a1 : 16'h000c) : 16'h0000;
+// custom NMI vector address output $a1000c
+assign nmi_adr_out = ovr ? (!cpu_address_in[1] ? 16'h00a1 : 16'h000c) : 16'h0000; 
 
 // freeze button
 always @ (posedge clk) begin

--- a/src/minimig.v
+++ b/src/minimig.v
@@ -166,7 +166,7 @@ module minimig
 	//sram pins
 	output [15:0] ram_data,			//sram data bus
 	input	 [15:0] ramdata_in,		//sram data bus in
-	output [21:1] ram_address,		//sram address bus
+	output [23:1] ram_address,		//sram address bus
 	output        _ram_bhe,			//sram upper byte select
 	output        _ram_ble,			//sram lower byte select
 	output        _ram_we,			//sram write enable
@@ -276,7 +276,7 @@ wire [15:0] ar3_data_out;	//Action Replay data out
 //local signals for address bus
 wire [23:1] cpu_address_out;	//cpu address out
 wire [20:1] dma_address_out;	//agnus address out
-wire [18:1] ram_address_out;	//ram address out
+wire [23:1] ram_address_out;	//ram address out
 
 //local signals for control bus
 wire        ram_rd;					//ram read enable

--- a/src/minimig_bankmapper.v
+++ b/src/minimig_bankmapper.v
@@ -1,5 +1,11 @@
 //This module maps physical 512KB blocks of every memory chip to different memory ranges in Amiga
-
+//
+//Since we currently have 8M for non-fastram, this was simplified to
+// use the full address for mapping.  We only use this part to signal
+// that ram access should occur and to emulate the mirroring behaviour
+// of the lower 2M when less than 2M chipram is selected. Moreover we
+// use sel_kick downstream, because there is no boot overlay
+// information in the address alone.
 
 module minimig_bankmapper
 (
@@ -15,50 +21,25 @@ module minimig_bankmapper
 	input	cart,				// Action Reply memory range select
 	input	aron,				// Action Reply enable
   input ecs,        // ECS chipset enable
-	input	[3:0] memory_config,// memory configuration
+	input	[1:0] memory_config,// memory configuration
 	output	reg [7:0] bank		// bank select
+
 );
 
+   
+   
 
 always @(*)
-begin
-  case ({aron,memory_config})
-    5'b0_0000 : bank = {  kick, kick1mb,  1'b0,  1'b0,   1'b0,  1'b0,          1'b0, chip3 | chip2 | chip1 | chip0 }; // 0.5M CHIP
-    5'b0_0001 : bank = {  kick, kick1mb,  1'b0,  1'b0,   1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP
-    5'b0_0010 : bank = {  kick, kick1mb,  1'b0,  1'b0,   1'b0, chip2,         chip1,                         chip0 }; // 1.5M CHIP
-    5'b0_0011 : bank = {  kick, kick1mb,  1'b0,  1'b0,  chip3, chip2,         chip1,                         chip0 }; // 2.0M CHIP
-    5'b0_0100 : bank = {  kick, kick1mb,  1'b0, slow0,   1'b0,  1'b0,          1'b0, chip0 | (chip1 & !ecs) | chip2 | (chip3 & !ecs) }; // 0.5M CHIP + 0.5MB SLOW
-    5'b0_0101 : bank = {  kick, kick1mb,  1'b0, slow0,   1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP + 0.5MB SLOW
-    5'b0_0110 : bank = {  kick, kick1mb,  1'b0, slow0,   1'b0, chip2,         chip1,                         chip0 }; // 1.5M CHIP + 0.5MB SLOW
-    5'b0_0111 : bank = {  kick, kick1mb,  1'b0, slow0,  chip3, chip2,         chip1,                         chip0 }; // 2.0M CHIP + 0.5MB SLOW
-    5'b0_1000 : bank = {  kick, kick1mb, slow1, slow0,   1'b0,  1'b0,          1'b0, chip3 | chip2 | chip1 | chip0 }; // 0.5M CHIP + 1.0MB SLOW
-    5'b0_1001 : bank = {  kick, kick1mb, slow1, slow0,   1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP + 1.0MB SLOW
-    5'b0_1010 : bank = {  kick, kick1mb, slow1, slow0,   1'b0, chip2,         chip1,                         chip0 }; // 1.5M CHIP + 1.0MB SLOW
-    5'b0_1011 : bank = {  kick, kick1mb, slow1, slow0,  chip3, chip2,         chip1,                         chip0 }; // 2.0M CHIP + 1.0MB SLOW
-    5'b0_1100 : bank = {  kick, kick1mb, slow1, slow0,   1'b0,  1'b0,          1'b0, chip3 | chip2 | chip1 | chip0 }; // 0.5M CHIP + 1.5MB SLOW
-    5'b0_1101 : bank = {  kick, kick1mb, slow1, slow0,   1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP + 1.5MB SLOW
-    5'b0_1110 : bank = {  kick, kick1mb, slow1, slow0,   1'b0, chip2,         chip1,                         chip0 }; // 1.5M CHIP + 1.5MB SLOW
-    5'b0_1111 : bank = {  kick, kick1mb, slow1, slow0,  chip3, chip2,         chip1,                         chip0 }; // 2.0M CHIP + 1.5MB SLOW
-   
-    5'b1_0000 : bank = {  kick, kick1mb, cart,   1'b0,   1'b0,  1'b0,  1'b0, chip0 | chip1 | chip2 | chip3 }; // 0.5M CHIP
-    5'b1_0001 : bank = {  kick, kick1mb, cart,   1'b0,   1'b0,  1'b0, chip1 | chip3, chip0 | chip2 }; // 1.0M CHIP
-    5'b1_0010 : bank = {  kick, kick1mb, cart,   1'b0,   1'b0, chip2, chip1, chip0 }; // 1.5M CHIP
-    5'b1_0011 : bank = {  kick, kick1mb, cart,   1'b0,  chip3, chip2, chip1, chip0 }; // 2.0M CHIP
-    5'b1_0100 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0, 1'b0, chip0 | (chip1 & !ecs) | chip2 | (chip3 & !ecs) }; // 0.5M CHIP + 0.5MB SLOW
-    5'b1_0101 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0, chip1 | chip3, chip0 | chip2 }; // 1.0M CHIP + 0.5MB SLOW
-    5'b1_0110 : bank = {  kick, kick1mb, cart,  slow0,   1'b0, chip2, chip1, chip0 }; // 1.5M CHIP + 0.5MB SLOW
-    5'b1_0111 : bank = {  kick, kick1mb, cart,  slow0,  chip3, chip2, chip1, chip0 }; // 2.0M CHIP + 0.5MB SLOW
-    5'b1_1000 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0,  1'b0, chip0 | chip1 | chip2 | chip3 }; // 0.5M CHIP + 1.0MB SLOW
-    5'b1_1001 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0, chip1 | chip3, chip0 | chip2 }; // 1.0M CHIP + 1.0MB SLOW
-    5'b1_1010 : bank = {  kick, kick1mb, cart,  slow0,   1'b0, chip2, chip1, chip0 }; // 1.5M CHIP + 1.0MB SLOW
-    5'b1_1011 : bank = {  kick, kick1mb, cart,  slow0,  chip3, chip2, chip1, chip0 }; // 2.0M CHIP + 1.0MB SLOW
-    5'b1_1100 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0, 1'b0, chip0 | chip1 | chip2 | chip3 }; // 0.5M CHIP + 1.5MB SLOW
-    5'b1_1101 : bank = {  kick, kick1mb, cart,  slow0,   1'b0,  1'b0, chip1 | chip3, chip0 | chip2 }; // 1.0M CHIP + 1.5MB SLOW
-    5'b1_1110 : bank = {  kick, kick1mb, cart,  slow0,   1'b0, chip2, chip1, chip0 }; // 1.5M CHIP + 1.5MB SLOW
-    5'b1_1111 : bank = {  kick, kick1mb, cart,  slow0,  chip3, chip2, chip1, chip0 }; // 2.0M CHIP + 1.5MB SLOW
-  endcase
-end
+  begin
+     bank[7:4] = { kick,  kick1mb  | slow0 | slow1 | slow2 | cart, chip3 | chip2 | chip1 | chip0, 1'b0};
+   case (memory_config)
+    5'b00 : bank[3:0] = {    1'b0,  1'b0,          1'b0, chip3 | chip2 | chip1 | chip0 }; // 0.5M CHIP
+    5'b01 : bank[3:0] = {    1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP
+    5'b10 : bank[3:0] = {    1'b0, chip2,         chip1,                         chip0 }; // 1.5M CHIP
+    5'b11 : bank[3:0] = {   chip3, chip2,         chip1,                         chip0 }; // 2.0M CHIP
+	   endcase
 
+ end
 
 endmodule
 

--- a/src/minimig_sram_bridge.v
+++ b/src/minimig_sram_bridge.v
@@ -13,7 +13,7 @@ module minimig_sram_bridge
 	input	c3,							// clock enable signal	
 	//chipset internal port
 	input	[7:0] bank,					// memory bank select (512KB)
-	input	[18:1] address_in,			// bus address
+	input	[23:1] address_in,			// bus address
 	input	[15:0] data_in,				// bus data in
 	output	[15:0] data_out,			// bus data out
 	input	rd,			   				// bus read
@@ -31,7 +31,7 @@ module minimig_sram_bridge
 	output	_ble,   				// sram lower byte
 	output	_we,				// sram write enable
 	output	_oe,				// sram output enable
-	output	[21:1] address,			// sram address bus
+	output	[23:1] address,			// sram address bus
 	output	[15:0] data,	  			// sram data das
 	input	[15:0] ramdata_in	  		// sram data das in
 );	 
@@ -72,7 +72,8 @@ wire	enable;				// indicates memory access cycle
 
 // generate enable signal if any of the banks is selected
 //assign enable = |bank[7:0];
-assign enable = (bank[7:0]==8'b00000000) ? 1'b0 : 1'b1;
+   
+   assign enable =  (bank[7:0]==8'b00000000) ? 1'b0 : 1'b1;
 
 // generate _we
 assign _we = (!hwr && !lwr) | !enable;
@@ -129,7 +130,11 @@ always @(posedge clk)
 //		_ce[3:0] <= {~|bank[7:6],~|bank[5:4],~|bank[3:2],~|bank[1:0]};
 
 // ram address bus
-assign		address = {bank[7]|bank[6]|bank[5]|bank[4],  bank[7]|bank[6]|bank[3]|bank[2],  bank[7]|bank[5]|bank[3]|bank[1],  address_in[18:1]};
+//assign		address = {bank[7]|bank[6]|bank[5]|bank[4],  bank[7]|bank[6]|bank[3]|bank[2],  bank[7]|bank[5]|bank[3]|bank[1],  address_in[18:1]};
+// bank[7] is sel_kick from gary, only used for ovl during boot. bank[5] is sel_chipram -> use chipram mapping. a0-ff is mapped to 20-7f
+
+   assign address = bank[7]? {5'b0111_1,address_in[18:1]}: (bank[5]?  {3'b0, bank[3]|bank[2], bank[3]|bank[1], address_in[18:1]} :  {1'b0,address_in[22:1]});
+   
 //assign address = {bank[7]|bank[5]|bank[3]|bank[1],address_in[18:1]};
 //always @(posedge clk28m)
 //	if (c1 && !c3 && enable)	// set address in Q1		

--- a/src/sdram/sdram_ctrl.v
+++ b/src/sdram/sdram_ctrl.v
@@ -40,7 +40,7 @@ module sdram_ctrl(
   output reg  [  2-1:0] dqm,
   inout  wire [ 16-1:0] sdata,
   // chip
-  input  wire    [23:1] chipAddr,
+  input  wire    [22:1] chipAddr, //we only use the first 8M block of the RAM for non-fastram
   input  wire           chipL,
   input  wire           chipU,
   input  wire           chipRW,
@@ -53,7 +53,7 @@ module sdram_ctrl(
   input  wire [  6-1:0] cpustate,
   input  wire           cpuL,
   input  wire           cpuU,
-  input  wire           cpu_dma,
+//  input  wire           cpu_dma, //not used at all!
   input  wire [ 16-1:0] cpuWR,
   output wire [ 16-1:0] cpuRD,
   output reg            enaWRreg,
@@ -237,7 +237,7 @@ cpu_cache_new cpu_cache (
   .sdr_read_req     (cache_req),                    // sdram read request from cache
   .sdr_read_ack     (readcache_fill),               // sdram read acknowledge to cache
   .snoop_act        (snoop_act),                    // snoop act (write only - just update existing data in cache)
-  .snoop_adr        ({1'b0, chipAddr, 1'b0}),       // snoop address
+  .snoop_adr        ({2'b00, chipAddr, 1'b0}),       // snoop address
   .snoop_dat_w      (chipWR)                        // snoop write data
 );
 
@@ -542,7 +542,7 @@ always @ (posedge sysclk) begin
           cas_dqm             <= {chipU,chipL};
           sd_cs               <= 4'b1110; // ACTIVE
           sd_ras              <= 1'b0;
-          casaddr             <= {1'b0, chipAddr, 1'b0};
+          casaddr             <= {2'b00, chipAddr, 1'b0};
           cas_sd_cas          <= 1'b0;
           cas_sd_we           <= chipRW;
         end


### PR DESCRIPTION
…address

- now using the full 8M (1st sram bank) for everything chipset related
- therefore 1mKickrom, hrtmon and 1.5M slowram can be used simulaneously, debug ROM (f0-f7) could be added easily.
- fixed some bugs in the fast ram code (TG68K.vhd) (writeprotect kickrom, override NMI vector)
- removed some unused wires