### PR TITLE
fixed a memory mapping bug in TK68K caused by the last commit.

### DIFF
--- a/Minimig.qpf
+++ b/Minimig.qpf
@@ -1,12 +1,31 @@
+# -------------------------------------------------------------------------- #
 #
-# please keep this file read-only!
-# Quartus changes this file everytime revision is switched, 
-# and it will be marked as changed with every commit.
+# Copyright (C) 2018  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and its AMPP partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel FPGA IP License Agreement, or other applicable license
+# agreement, including, without limitation, that your use is for
+# the sole purpose of programming logic devices manufactured by
+# Intel and sold by Intel or its authorized distributors.  Please
+# refer to the applicable agreement for further details.
 #
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 18.1.0 Build 625 09/12/2018 SJ Lite Edition
+# Date created = 20:39:47  May 01, 2019
+#
+# -------------------------------------------------------------------------- #
 
-QUARTUS_VERSION = "16.1"
-DATE = "23:13:02  April 27, 2017"
+QUARTUS_VERSION = "18.1"
+DATE = "20:39:47  May 01, 2019"
 
 # Revisions
 
 PROJECT_REVISION = "Minimig"
+PROJECT_REVISION = "test"

--- a/src/cart.v
+++ b/src/cart.v
@@ -41,34 +41,37 @@
 
 module cart
 (
-  input  wire           clk,
-  input  wire           clk7_en,
-  input  wire           clk7n_en,
-  input  wire           cpu_rst,
-  input  wire [ 24-1:1] cpu_address,
-  input  wire [ 24-1:1] cpu_address_in,
-  input  wire           _cpu_as,
-  input  wire           cpu_rd,
-  input  wire           cpu_hwr,
-  input  wire           cpu_lwr,
-  input  wire [ 32-1:0] cpu_vbr,
-  input  wire [  9-1:1] reg_address_in,
-  input  wire [ 16-1:0] reg_data_in,
-  input  wire           dbr,
-  input  wire           ovl,
-  input  wire           freeze,
+  input wire 		clk,
+  input wire 		clk7_en,
+  input wire 		clk7n_en,
+  input wire 		cpu_rst,
+  input wire [ 24-1:1] 	cpu_address,
+  input wire [ 24-1:1] 	cpu_address_in,
+  input wire 		_cpu_as,
+  input wire 		cpu_rd,
+  input wire 		cpu_hwr,
+  input wire 		cpu_lwr,
+  input wire [ 32-1:0] 	cpu_vbr,
+  input wire [ 9-1:1] 	reg_address_in,
+  input wire [ 16-1:0] 	reg_data_in,
+  input wire 		dbr,
+  input wire 		ovl,
+  input wire 		freeze, 
+  input wire 		cpuhlt,
   output wire [ 16-1:0] cart_data_out,
-  output reg            int7 = 1'b0,
-  output wire           sel_cart,
-  output wire           ovr,
+  output reg 		int7 = 1'b0,
+  output wire 		sel_cart,
+  output wire 		ovr
+ 
 //  output reg            aron = 1'b1
-  output wire           aron
-);
+//  output wire 		aron //not needed -- remove!
+ );
 
 
 //// internal signals ////
 reg  [32-1:0] nmi_vec_adr=0;
 reg           freeze_d=0;
+reg 	      stealth; //hide till first freeze request   
 wire          freeze_req;
 wire          int7_req;
 wire          int7_ack;
@@ -85,7 +88,9 @@ reg  [16-1:0] custom_mirror [0:256-1];
 
 //// code ////
 
-// cart is activated by writing to its area during bootloading
+// currently cart is activated by the first freeze request of the cia.    
+// OLD: cart is activated by writing to its area during bootloading
+/*
 `define ARON_HACK
 `ifndef ARON_HACK
 always @ (posedge clk) begin
@@ -98,9 +103,11 @@ end
 // TODO enable cart from firmware when uploading
 assign aron = 1'b1;
 `endif
-
-// cart selected
-assign sel_cart = ~dbr && (cpu_address_in[23:19]==5'b1010_0); // $A00000
+*/
+ 
+//  cart selected, is in stealth mode until first freeze, has to be available during halt to allow userio 
+   assign sel_cart = ~dbr && (cpu_address_in[23:19]==5'b1010_0) && (stealth | cpuhlt); // $A00000
+   
 
 // latch VBR + NMI vector offset
 always @ (posedge clk) begin
@@ -168,16 +175,22 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (cpu_rst)
-      active <= #1 1'b0;
+      begin
+	 active <= #1 1'b0;
+	 stealth <= #1 1'b0;
+      end
     else if (/*aron &&*/ l_int7 && l_int7_ack && cpu_rd)
-      active <= #1 1'b1;
+      begin
+	 active <= #1 1'b1;
+	 stealth <= #1 1'b1;
+      end
     else if (sel_cart && cpu_rd)
       active <= #1 1'b0;
   end
 end
 
 // custom registers mirror memory
-assign sel_custom_mirror = ~dbr && cpu_rd && (cpu_address_in[23:12]==12'b1010_1001_1111); // $A9F000
+assign sel_custom_mirror = ~dbr && cpu_rd && (cpu_address_in[23:12]==12'b1010_1001_1111) &&stealth; // $A9F000
 always @ (posedge clk) begin
   if (clk7_en) begin
     custom_mirror[reg_address_in] <= #1 reg_data_in;

--- a/src/gary.v
+++ b/src/gary.v
@@ -83,6 +83,7 @@ module gary
 	output reg [2:0] sel_slow, //select slowfast memory ($C0000)
 	output reg 	 sel_kick, //select kickstart rom
 	output reg 	 sel_kick1mb, // 1MB kickstart rom 'upper' half
+        output reg       sel_kick256kmirror, //mirror the f8 to fc in a1k
 	output 		 sel_cia, //select CIA space
 	output 		 sel_cia_a, //select cia A
 	output 		 sel_cia_b, //select cia B
@@ -127,11 +128,13 @@ begin
 		sel_chip[1] = ~dma_address_in[20] &  dma_address_in[19];
 		sel_chip[2] =  dma_address_in[20] & ~dma_address_in[19];
 		sel_chip[3] =  dma_address_in[20] &  dma_address_in[19];
-		sel_slow[0] = ( ecs && memory_config==4'b0100 && dma_address_in[20:19]==2'b01) ? 1'b1 : 1'b0;
+		sel_slow[0] = ( ecs && memory_config==4'b0100 && dma_address_in[20:19]==2'b01) ? 1'b1 : 1'b0; //use slow0 as chipmem, when only chip0 and slow0 are enabled.
 		sel_slow[1] = 1'b0;
 		sel_slow[2] = 1'b0;
 	   sel_kick    = 1'b0;
 	   sel_kick1mb = 1'b0;
+	   sel_kick256kmirror = 1'b0;
+	   
 	end
 	else
 	begin
@@ -143,7 +146,8 @@ begin
 		sel_slow[1] = t_sel_slow[1];
 		sel_slow[2] = t_sel_slow[2];
 		sel_kick    = (cpu_address_in[23:19]==5'b1111_1 && (cpu_rd || cpu_hlt)) || (cpu_rd && ovl && cpu_address_in[23:19]==5'b0000_0) ? 1'b1 : 1'b0; //$F80000 - $FFFFF
-	   sel_kick1mb = (cpu_address_in[23:19]==5'b1110_0 && (cpu_rd || cpu_hlt)) ? 1'b1 : 1'b0; // $E00000 - $E7FFFF
+	 sel_kick256kmirror = (cpu_address_in[23:19]==5'b1111_1 &&  cpu_rd && !ovl && !cpu_hlt)  ? 1'b1 : 1'b0;
+	        sel_kick1mb = (cpu_address_in[23:19]==5'b1110_0 && (cpu_rd || cpu_hlt)) ? 1'b1 : 1'b0; // $E00000 - $E7FFFF
 	end
 end
 

--- a/src/minimig.v
+++ b/src/minimig.v
@@ -302,6 +302,7 @@ wire  [3:0] sel_chip;			//chip ram select
 wire  [2:0] sel_slow;			//slow ram select
 wire        sel_kick;				//rom select
 wire        sel_kick1mb;     // 1MB upper rom select
+wire        sel_kick256kmirror; // mirror f8-fb to fc-ff in a1k mode    
 wire        sel_cia;				//CIA address space
 wire        sel_reg;				//chip register select
 wire        sel_rtc;
@@ -738,7 +739,8 @@ minimig_bankmapper BMAP1
 	.slow2(sel_slow[2]),
 	.kick(sel_kick),
 	.kick1mb(sel_kick1mb),
-	.cart(sel_cart),
+        .kick256kmirror(sel_kick256kmirror),
+ 	.cart(sel_cart),
 	.aron(aron),
 	.ecs(|chipset_config[4:3]),
 	.memory_config(memory_config[3:0]),
@@ -789,7 +791,8 @@ cart CART1
   .int7           (int7           ),
   .sel_cart       (sel_cart       ),
   .ovr            (ovr            ),
-  .aron           (aron           )
+//  .aron           (aron           ),
+  .cpuhlt         (cpuhlt)
 );
 
 //level 7 interrupt for CPU
@@ -827,7 +830,8 @@ gary GARY1
 	.sel_slow(sel_slow),
 	.sel_kick(sel_kick),
 	.sel_kick1mb(sel_kick1mb),
-	.sel_cia(sel_cia),
+        .sel_kick256kmirror(sel_kick256kmirror),
+        .sel_cia(sel_cia),
 	.sel_reg(sel_reg),
 	.sel_cia_a(sel_cia_a),
 	.sel_cia_b(sel_cia_b),

--- a/src/minimig_bankmapper.v
+++ b/src/minimig_bankmapper.v
@@ -9,20 +9,21 @@
 
 module minimig_bankmapper
 (
-	input	chip0,				// chip ram select: 1st 512 KB block
-	input	chip1,				// chip ram select: 2nd 512 KB block
-	input	chip2,				// chip ram select: 3rd 512 KB block
-	input	chip3,				// chip ram select: 4th 512 KB block
-	input	slow0,				// slow ram select: 1st 512 KB block 
-	input	slow1,				// slow ram select: 2nd 512 KB block 
-	input	slow2,				// slow ram select: 3rd 512 KB block 
-	input	kick,				// Kickstart ROM address range select
-  input kick1mb,    // 1MB Kickstart 'upper' half
-	input	cart,				// Action Reply memory range select
-	input	aron,				// Action Reply enable
-  input ecs,        // ECS chipset enable
-	input	[1:0] memory_config,// memory configuration
-	output	reg [7:0] bank		// bank select
+	input 		 chip0, // chip ram select: 1st 512 KB block
+	input 		 chip1, // chip ram select: 2nd 512 KB block
+	input 		 chip2, // chip ram select: 3rd 512 KB block
+	input 		 chip3, // chip ram select: 4th 512 KB block
+	input 		 slow0, // slow ram select: 1st 512 KB block 
+	input 		 slow1, // slow ram select: 2nd 512 KB block 
+	input 		 slow2, // slow ram select: 3rd 512 KB block 
+	input 		 kick, // Kickstart ROM address range select
+	input 		 kick1mb, // 1MB Kickstart 'upper' half
+	input 		 kick256kmirror, //mirror f8-fb to fc-ff in a1k mode
+	input 		 cart, // Action Reply memory range select
+	input 		 aron, // Action Reply enable
+	input 		 ecs, // ECS chipset enable
+	input [1:0] 	 memory_config,// memory configuration
+	output reg [7:0] bank		// bank select
 
 );
 
@@ -31,7 +32,7 @@ module minimig_bankmapper
 
 always @(*)
   begin
-     bank[7:4] = { kick,  kick1mb  | slow0 | slow1 | slow2 | cart, chip3 | chip2 | chip1 | chip0, 1'b0};
+     bank[7:4] = { kick,kick256kmirror , chip3 | chip2 | chip1 | chip0,  kick1mb  | slow0 | slow1 | slow2 | cart} ;
    case (memory_config)
     5'b00 : bank[3:0] = {    1'b0,  1'b0,          1'b0, chip3 | chip2 | chip1 | chip0 }; // 0.5M CHIP
     5'b01 : bank[3:0] = {    1'b0,  1'b0, chip3 | chip1,                 chip2 | chip0 }; // 1.0M CHIP


### PR DESCRIPTION
The ram bank of hrtmon (a0-a7) is now invisible until the first freeze
request. In particular, it is invisible when hrtmon is disabled.