### PR TITLE
Restore some Turbo chipram/ exceptions

### DIFF
--- a/src/minimig.v
+++ b/src/minimig.v
@@ -423,7 +423,7 @@ end
 assign pwr_led = ~(_led & led_dim);
 
 assign memcfg = {memory_config[7],memory_config[5:0]};
-assign cachecfg = {cachecfg_pre[2], ~ovl, ~ovl};
+assign cachecfg = {cachecfg_pre[2], (rom_readonly && !ovl && cachecfg_pre[1]), (!ovl && (cachecfg_pre[0] && cpu_custom) && (&memory_config[1:0]))};
 
 // NTSC/PAL switching is controlled by OSD menu, change requires reset to take effect
 always @(posedge clk) if (clk7_en && reset) ntsc <= chipset_config[1];


### PR DESCRIPTION
Once this was removed in https://github.com/MiSTer-devel/Minimig-AGA_MiSTer/commit/87e4847549e327e0e8b9020ea47d1d0d7f3923f1#diff-0265045cedb84b19074d6edd2283f1e8 :
```
// turbo chipram only when in AGA mode, no overlay is active, cachecfg[0] (fast chip) is enabled or Agnus allows CPU on the bus and chipRAM=2MB
assign turbochipram = !ovl && (cachecfg[0] && cpu_custom) && (&memory_config[1:0]);

// turbo kickstart only when no overlay is active and cachecfg[1] (fast kick) enabled or AGA mode is enabled
assign turbokick = rom_readonly && !ovl && cachecfg[1];
//writing to the ROM area is not implemented in turbo mode (see tg68k.vhd)
```
and replaced with:
```
assign cachecfg = {cachecfg_pre[2], ~ovl, ~ovl};
...
reg ovl; //kickstart overlay enable
always @(posedge clk) begin
	if(~_cpu_reset | ~_cpu_reset_in)       ovl <= 1;
	else if(sel_cia_a & (cpu_lwr|cpu_hwr)) ovl <= 0;
end
```
Some graphical and sound glitches started appearing in some games. At first it looked like everything was ok on M68K core, but tg68k core was showing these problems. Unless there's a better fix, this fixes it for me on both cores.