### PR TITLE
Move register declarations outside always block

### DIFF
--- a/src/agnus_bitplanedma.v
+++ b/src/agnus_bitplanedma.v
@@ -146,12 +146,11 @@ wire         ddfseq_match;
 // ECS: DDFSTOP = $E2($E3) display data fetch stopped ($00 stops the display as well)
 // ECS: DDFSTOP = $E4 display data fetch not stopped
 
+reg [8:0] best_hdiwstrt, cur_hdiwstrt, prev_hdiwstrt;
+reg [8:0] best_hdiwstop, cur_hdiwstop, prev_hdiwstop;
+reg [10:0] d_hde;
 
 always @ (posedge clk) begin
-	reg [8:0] best_hdiwstrt, cur_hdiwstrt, prev_hdiwstrt;
-	reg [8:0] best_hdiwstop, cur_hdiwstop, prev_hdiwstop;
-	reg [10:0] d_hde;
-
 	if (clk7_en) begin
 		if(!hpos) begin
 			if((hdiwstrt < hdiwstop) && ((best_hdiwstop-best_hdiwstrt)<(hdiwstop-hdiwstrt))) begin

--- a/src/ciaa.v
+++ b/src/ciaa.v
@@ -165,8 +165,9 @@ reg    freeze_reg=0;
 assign freeze = freeze_reg;
 
 // generate a keystrobe which is valid exactly one clk cycle
+reg kms_levelD;
+
 always @(posedge clk) begin
-	reg kms_levelD;
 	if (clk7n_en) begin
 		kms_levelD <= kms_level;
 		keystrobe <= (kms_level ^ kms_levelD) && (kbd_mouse_type == 2);

--- a/src/ddram_ctrl.v
+++ b/src/ddram_ctrl.v
@@ -90,8 +90,8 @@ reg  [1:0] writeBE;
 reg [28:1] writeAddr;
 reg [15:0] writeDat;
 
+reg [1:0] write_state = 0;
 always @ (posedge sysclk) begin
-	reg  [1:0] write_state;
 
 	if(~reset_n) begin
 		write_req   <= 0;
@@ -130,11 +130,11 @@ assign DDRAM_BURSTCNT = 1;
 
 reg [15:0] ddr_data;
 
-always @ (posedge sysclk) begin
-	reg  [2:0] state = 0;
-	reg  [1:0] ba;
-	reg [63:0] dout;
+reg  [2:0] state;
+reg  [1:0] ba;
+reg [63:0] dout;
 
+always @ (posedge sysclk) begin
 	cache_fill <= 0;
 	ddr_data <= dout[{ba, 4'b0000} +:16];
 

--- a/src/sdram_ctrl.v
+++ b/src/sdram_ctrl.v
@@ -84,8 +84,8 @@ localparam [2:0]
 ////////////////////////////////////////
 
 reg reset;
+reg [7:0] reset_cnt;
 always @(posedge sysclk) begin
-	reg [7:0] reset_cnt;
 
 	if(!reset_n) begin
 		reset_cnt     <= 0;
@@ -151,8 +151,9 @@ reg  [1:0] write_dqm;
 reg [24:1] writeAddr;
 reg [15:0] writeDat;
 
+reg  [1:0] write_state;
+
 always @ (posedge sysclk) begin
-	reg  [1:0] write_state;
 
 	if(~reset_n) begin
 		write_req   <= 0;
@@ -191,8 +192,8 @@ assign ramready = cache_rd_ack || write_ena;
 //// chip line read ////
 reg [15:0] chip48_1, chip48_2, chip48_3;
 
+reg [15:0] sdata_chip;
 always @ (posedge sysclk) begin
-	reg [15:0] sdata_chip;
 
 	sdata_chip <= sdata_reg;
 	if(slot_type == CHIP) begin
@@ -231,9 +232,8 @@ end
 
 //// sdram state ////
 reg [3:0] sdram_state;
+reg old_7m;
 always @ (posedge sysclk) begin
-	reg old_7m;
-
 	sdram_state <= sdram_state + 1'd1;
 
 	old_7m <= c_7m;
@@ -246,14 +246,14 @@ reg  [2:0] slot_type = IDLE;
 reg [15:0] sdata_reg;
 reg        chipWE;
 
+reg        cas_sd_cas;
+reg        cas_sd_we;
+reg  [1:0] cas_dqm;
+reg [15:0] datawr;
+reg  [9:0] casaddr;
+reg  [3:0] rcnt;
 always @ (posedge sysclk) begin
-	reg        cas_sd_cas;
-	reg        cas_sd_we;
-	reg  [1:0] cas_dqm;
-	reg [15:0] datawr;
-	reg  [9:0] casaddr;
-	reg  [3:0] rcnt;
-	
+
 	sd_clk <= sdram_state[0];
 
 	if(~sdram_state[0]) begin

--- a/src/userio.v
+++ b/src/userio.v
@@ -287,9 +287,9 @@ reg  [ 7:0] xcount;
 reg  [ 7:0] ycount;
 
 // mouse counters
+reg old_level;
 always @(posedge clk) begin
-	reg old_level;
-	
+
 	old_level <= kms_level;
 
 	if(reset) begin
@@ -324,10 +324,10 @@ reg [4:0] t_cpu_config = 0;
 reg [4:0] t_chipset_config = 0;
 
 // configuration changes only while reset is active
-always @(posedge clk) begin
-	reg [4:0] ide_cfg = 0;
-	reg [1:0] cpu_cfg = 0;
+reg [4:0] ide_cfg = 0;
+reg [1:0] cpu_cfg = 0;
 
+always @(posedge clk) begin
 	if (reset) begin
 		chipset_config <= t_chipset_config;
 		ide_cfg <= t_ide_config;
@@ -359,14 +359,14 @@ wire floppy_cfg_sel   = (cmd[3:0] == 7); // XXXXXFFS || floppy config   | FF - d
 wire harddisk_cfg_sel = (cmd[3:0] == 8); // XXXXXSMC || harddisk config | S - enable slave HDD, M - enable master HDD, C - enable HDD controler
 wire joystick_cfg_sel = (cmd[3:0] == 9); // XXXXXCAA || joystick config | C - CD32pad mode, AA - autofire rate
 
-always @(posedge clk) begin
-	reg       has_cmd;
-	reg       mrx;
-	reg       btoggle;
-	reg       old_ack;
-	reg [2:0] bcnt;
-	reg       bootrom_r;
+reg       has_cmd;
+reg       mrx;
+reg       btoggle;
+reg       old_ack;
+reg [2:0] bcnt;
+reg       bootrom_r;
 
+always @(posedge clk) begin
 	old_ack <= host_ack;
 	if (old_ack & ~host_ack) begin
 		IO_WAIT  <= 0;


### PR DESCRIPTION
Having them inside an always block is a SystemVerilog extension, but this can be trivially fixed by moving them outside the always block; this makes the code more portable (in particular, Yosys can now compile the Verilog part of the core).

No functional changed, as this is just a refactor for standards compliance.