### PR TITLE
Fix serial print trashing a6

### DIFF
--- a/extra/rtg_driver/MiSTer.card.asm
+++ b/extra/rtg_driver/MiSTer.card.asm
@@ -138,8 +138,10 @@ bugprintf:
         movem.l (sp)+,d0-d1/a0-a3/a6
         rts
 
-.putch: move.l  a3,a6
+.putch: move.l	a6,-(sp)
+        move.l  a3,a6
         jmp     -516(a6)                ; _LVORawPutChar (execPrivate9)
+        move.l	(sp)+,a6
 _bugprintf_end:
         rts
         ENDC


### PR DESCRIPTION
Fix serial print trashing a6 from fpgaarcade https://github.com/FPGAArcade/amiga_code/commit/175ee6798b763846025a2749198cd8d4eb7a0f5b