### PR TITLE
Fix Hybris scoreboard

### DIFF
--- a/rtl/denise_sprites_shifter.v
+++ b/rtl/denise_sprites_shifter.v
@@ -74,10 +74,10 @@ always @(posedge clk)
     load <= armed && (hpos[7:0] == hstart[7:0]) && (fmode[15] || (hpos[8] == hstart[8])) ? 1'b1 : 1'b0;
   end
 
-always @(posedge clk)
-  if (clk7_en) begin
-    load_del <= load;
-  end
+//always @(posedge clk)
+//  if (clk7_en) begin
+//    load_del <= load;  // AMR - delaying this screws up the scoreboard in hybris.
+//  end
 
 //--------------------------------------------------------------------------------------
 
@@ -119,7 +119,7 @@ end
 
 // sprite shift register
 always @(posedge clk)
-  if (clk7_en && load_del) // load new data into shift register
+  if (clk7_en && load) // AMR - load_del) // load new data into shift register
   begin
     shifta[63:0] <= datla[63:0];
     shiftb[63:0] <= datlb[63:0];
@@ -131,8 +131,13 @@ always @(posedge clk)
   end
 
 // assign serialized output data
-assign sprdata[1:0] = {shiftb[63],shifta[63]};
+// AMR - register the output data to delay it by one clk7, compensating for removing load_del
+// Fixed highres sprites by pipelining shifter output.
+reg [7:0] sprdata_r;
+always @(posedge clk)
+  sprdata_r <= {shiftb[63],shifta[63],sprdata_r[7:2]}; // Ugly - are we masking a copper timing problem here?
 
+assign sprdata[1:0] = sprdata_r[1:0]; // {shiftb[63],shifta[63]};
 //--------------------------------------------------------------------------------------
 
 endmodule


### PR DESCRIPTION
This is a fix for Hybris scoreboard graphics corruption when running the game on OCS, copied from the recent work by robinsonb5 for MIST/TC64 here
https://github.com/retrofun/MinimigAGA-MiST-TC64/commit/7abd0e3fb8594ae2ae6e6b36a3ee32fca6b7ad61
and here
https://github.com/retrofun/MinimigAGA-MiST-TC64/commit/b0b8d98c3a59018ad008e6ee81f34198021ec4dd

I tested that it fixes the scoreboard, but I am not sure if this way of fixing it is what we want.

Before:

![20240119_183032-screen](https://github.com/MiSTer-devel/Minimig-AGA_MiSTer/assets/13071547/f6d0d5e5-cdca-439d-a505-6bd3a200cc62)

After:

![20240119_182736-screen](https://github.com/MiSTer-devel/Minimig-AGA_MiSTer/assets/13071547/bfa6b46f-1573-46aa-afc2-34015eb5245b)

More discussion here: https://github.com/MiSTer-devel/Minimig-AGA_MiSTer/issues/73

