### PR TITLE
Fixed up the TOD BCD confusion

### DIFF
--- a/rtl/cia_timerd.v
+++ b/rtl/cia_timerd.v
@@ -1,5 +1,6 @@
 // CIA Timer D - Time of Day (TOD) Clock Module
-// 24-bit BCD counter for real-time clock functionality
+// Implements Time of Day (TOD) functionality for Amiga CIA chip
+// Note: TOD is implemented as binary counter (Amiga style), not BCD (C64 style)
 // Counts external pulses (typically 50/60 Hz from power line frequency)
 // Includes alarm functionality for time-based interrupts
 module cia_timerd
@@ -10,10 +11,10 @@ module cia_timerd
   input   reset,          // Synchronous reset
 
   // Register select signals from address decoder
-  input   tlo,            // TOD low byte select (1/10 seconds) ($x8)
-  input   tme,            // TOD middle byte select (seconds) ($x9)
-  input  thi,             // TOD high byte select (minutes) ($xA)
-  input  tcr,             // Timer control register B select ($xF)
+  input   tlo,            // Timer low byte select (bits 7:0)
+  input   tme,            // Timer mid byte select (bits 15:8)
+  input  thi,             // Timer high byte select (bits 23:16)
+  input  tcr,             // Timer control register select
 
   input   [7:0] data_in,  // CPU data bus input
   output   reg [7:0] data_out, // CPU data bus output
@@ -25,16 +26,11 @@ module cia_timerd
   reg    latch_ena;       // TOD output latch control
   reg   count_ena;        // TOD counting enable
   reg    crb7;            // CRB bit 7: TOD/ALARM register select
-  reg    [23:0] tod;      // 24-bit TOD counter (BCD format)
-  reg    [23:0] alarm;    // 24-bit alarm register (BCD format)
-  reg    [23:0] tod_latch; // Latched TOD value for stable reading
+  reg    [23:0] tod;      // 24-bit TOD counter (binary, not BCD)
+  reg    [23:0] alarm;    // 24-bit alarm compare value
+  reg    [23:0] tod_latch; // TOD readout latch (for consistent multi-byte reads)
   reg    count_del;       // Delayed count signal for edge detection
-  reg    count_del2;      // delayed count signal for interrupt requesting
-
-// TOD Counter Format (BCD - Binary Coded Decimal):
-// Bits 23:16 - Minutes (00-59 BCD)
-// Bits 15:8  - Seconds (00-59 BCD)
-// Bits 7:0   - 1/10 seconds (00-99 BCD)
+  reg    count_del2;      // Double delayed count signal for interrupt generation
 
 // TOD Read Latching Mechanism:
 // Reading TOD registers must be done in specific order to ensure consistency
@@ -47,14 +43,15 @@ always @(posedge clk)
       latch_ena <= 1'd1;  // Latch enabled after reset
     else if (!wr)
     begin
-      if (thi && !crb7)   // Reading minutes with TOD selected
+      if (thi && !crb7)    // if MSB read and ALARM is not selected, hold data for subsequent reads
         latch_ena <= 1'd0; // Freeze latch to ensure consistent read
-      else if (tlo)       // Reading 1/10 seconds
+      else if (tlo)        // if LSB read, update data every clock
         latch_ena <= 1'd1; // Release latch for updates
     end
   end
 
-// Update TOD latch when enabled
+// TOD latch update
+// Captures current TOD value when latch is enabled
 always @(posedge clk)
   if (clk7_en) begin
     if (latch_ena)
@@ -67,11 +64,11 @@ always @(posedge clk)
 always @(*)
   if (!wr)
   begin
-    if (thi)      // High byte - minutes
+    if (thi)      // High byte of timer D
       data_out[7:0] = tod_latch[23:16];
-    else if (tme) // Middle byte - seconds
+    else if (tme) // Middle byte of timer D (latched)
       data_out[7:0] = tod_latch[15:8];
-    else if (tlo) // Low byte - 1/10 seconds
+    else if (tlo) // Low byte of timer D (latched)
       data_out[7:0] = tod_latch[7:0];
     else if (tcr) // Control register B bit 7 only
       data_out[7:0] = {crb7,7'b000_0000};
@@ -82,41 +79,41 @@ always @(*)
     data_out[7:0] = 8'd0;
 
 // TOD Write Control:
-// Writing to high/middle byte stops TOD counting
+// Writing to high byte stops TOD counting
 // Writing to low byte starts TOD counting again
 // This ensures consistent time setting
 always @(posedge clk)
   if (clk7_en) begin
     if (reset)
       count_ena <= 1'd1;  // Counting enabled after reset
-    else if (wr && !crb7) // Writing to TOD (not ALARM)
+    else if (wr && !crb7) // crb7==0 enables writing to TOD counter
     begin
-      if (thi/* || tme*/) // Writing minutes (or seconds)
-        count_ena <= 1'd0; // Stop counting during update
-      else if (tlo)       // Writing 1/10 seconds
-        count_ena <= 1'd1; // Resume counting
+      if (thi/* || tme*/) // Stop counting during update
+        count_ena <= 1'd0;
+      else if (tlo)       // write to LSB starts counting again
+        count_ena <= 1'd1;
     end
   end
 
 // TOD Counter
-// Note: Simplified implementation - counts binary, not true BCD
-// Real hardware would implement proper BCD counting with digit carries
-// AMR - emulate buggy TOD behaviour in Mid counter.Add commentMore actions
-reg todcarry;
+// Note: counts in binary, not BCD
+// Emulates buggy TOD behavior where carry from lower 12 bits
+// is delayed by one cycle when updating upper 12 bits
+reg todcarry; // Carry flag for delayed upper counter update
 always @(posedge clk)
   if (clk7_en) begin
     if (reset)
     begin
-      tod[23:0] <= 24'd0;  // Start at 00:00:00.0
+      tod[23:0] <= 24'd0;  // Clear counter on reset
     end
-    else if (wr && !crb7)  // CRB7=0 enables writing to TOD
+    else if (wr && !crb7)  // CRB7==0 enables writing to TOD counter
     begin
       if (tlo)
-        tod[7:0] <= data_in[7:0];    // Set 1/10 seconds
+        tod[7:0] <= data_in[7:0];
       if (tme)
-        tod[15:8] <= data_in[7:0];   // Set seconds
+        tod[15:8] <= data_in[7:0];
       if (thi)
-        tod[23:16] <= data_in[7:0];  // Set minutes
+        tod[23:16] <= data_in[7:0];
     end
     else if (count_ena && count) begin
 		todcarry <= &tod[11:0];
@@ -131,7 +128,7 @@ always @(posedge clk)
 // Written when CRB bit 7 = 1
 always @(posedge clk)
   if (clk7_en) begin
-    if (reset)
+    if (reset) // synchronous reset
     begin
       // Set alarm to maximum value (never match by default)
       alarm[7:0] <= 8'b1111_1111;
@@ -141,11 +138,11 @@ always @(posedge clk)
     else if (wr && crb7)  // CRB7=1 enables writing to ALARM
     begin
       if (tlo)
-        alarm[7:0] <= data_in[7:0];    // Set alarm 1/10 seconds
+        alarm[7:0] <= data_in[7:0];
       if (tme)
-        alarm[15:8] <= data_in[7:0];   // Set alarm seconds
+        alarm[15:8] <= data_in[7:0];
       if (thi)
-        alarm[23:16] <= data_in[7:0];  // Set alarm minutes
+        alarm[23:16] <= data_in[7:0];
     end
   end
 
@@ -159,17 +156,14 @@ always @(posedge clk)
       crb7 <= data_in[7];
   end
 
-// Edge detection for count input
-// Used to ensure alarm triggers only once when TOD matches
+// delayed count enable signal
 always @(posedge clk)
   if (clk7_en) begin
     count_del <= count & count_ena;
     count_del2 <= count_del & count_ena;
   end
 
-// Alarm interrupt generation
-// Triggers when TOD exactly matches ALARM value
-// count_del ensures single interrupt pulse
+// alarm interrupt request
 assign irq = (tod[23:0]==alarm[23:0] && (count_del || count_del2)) ? 1'b1 : 1'b0;
 
 


### PR DESCRIPTION
Fixing a thing what I missed. The old Commodore CIAs used BCD based TOD counter, where the Amiga CIA chips used a binary TOD counter. Fixing up a few more comments, and reverting a few of the original ones.