### PR TITLE
Fix from TC64: fixed CIA timing bug which more-or-less fixes Risky Wo…

### DIFF
--- a/rtl/cia_timera.v
+++ b/rtl/cia_timera.v
@@ -94,10 +94,17 @@ always @(posedge clk)
       tmlh[7:0] <= data_in[7:0];
   end
 
+reg thi_load_latched;
+wire thi_load_eclk= thi_load_latched & eclk;
+
 // Detect write to timer high byte
 // In stopped state or one-shot mode, this triggers timer reload
 always @(posedge clk)
   if (clk7_en) begin
+  	if(eclk)
+		  thi_load_latched<=1'b0;
+	  if (thi & wr & (~start | oneshot))
+		  thi_load_latched <= 1'b1;
     thi_load <= thi & wr & (~start | oneshot);
   end
 
@@ -105,7 +112,7 @@ always @(posedge clk)
 // 1. Force load strobe (bit 4 of control register)
 // 2. Write to high byte when stopped or in one-shot mode
 // 3. Timer underflow (automatic reload)
-assign reload = thi_load | forceload | underflow;
+assign reload = thi_load_eclk | forceload | underflow;
 
 // 16-bit down counter
 always @(posedge clk)

--- a/rtl/cia_timerb.v
+++ b/rtl/cia_timerb.v
@@ -96,14 +96,21 @@ always @(posedge clk)
       tmlh[7:0] <= data_in[7:0];
   end
 
+reg thi_load_latched;
+wire thi_load_eclk= thi_load_latched & eclk;
+
 // Detect write to timer high byte
 always @(posedge clk)
   if (clk7_en) begin
+  	if(eclk)
+		  thi_load_latched<=1'b0;
+	  if (thi & wr & (~start | oneshot))
+		  thi_load_latched <= 1'b1;
     thi_load <= thi & wr & (~start | oneshot);
   end
 
 // Timer reload conditions (same as Timer A)
-assign reload = thi_load | forceload | underflow;
+assign reload = thi_load_eclk | forceload | underflow;
 
 // 16-bit down counter
 always @(posedge clk)


### PR DESCRIPTION
…ods music and sound effects.

MiST-TC64 added a flip-flop to delay the timer reload by one eclk cycle for better hardware accuracy.

Fixes issue #15