### PR TITLE
Fix for Crazy Sexy Cool demo by Essence

### DIFF
--- a/rtl/denise.v
+++ b/rtl/denise.v
@@ -377,10 +377,11 @@ denise_sprites sprm0
 );
 
 // instantiate video priority logic module
+wire [2:1] nplayfield_masked = nplayfield & {window_ena,window_ena};
 denise_spritepriority spm0
 (
   .bplcon2(bplcon2[5:0]),
-  .nplayfield(nplayfield),
+  .nplayfield(nplayfield_masked),
   .nsprite(nsprite),
   .sprsel(sprsel)
 );


### PR DESCRIPTION
- Bitplane can no longer obscure sprites outside display window (ported from MiST fix made by Robinsonb5)