### PR TITLE
minimig: dual-mouse support — real second mouse on controller port 2

### DIFF
--- a/Minimig.sv
+++ b/Minimig.sv
@@ -50,6 +50,11 @@ wire  [7:0] kbd_mouse_data;
 wire        kbd_mouse_level;
 wire  [1:0] kbd_mouse_type;
 wire  [2:0] mouse_buttons;
+// second mouse (port 2) - dual-mouse support (auto-bound to hps_ext via .*)
+wire  [7:0] kbd_mouse2_data;
+wire        kbd_mouse2_level;
+wire  [1:0] kbd_mouse2_type;
+wire  [2:0] mouse2_buttons;
 wire [64:0] RTC;
 
 wire        ce_pix;
@@ -576,6 +581,10 @@ minimig minimig
 	.kbd_mouse_data (kbd_mouse_data ), // mouse direction data, keycodes
 	.kbd_mouse_type (kbd_mouse_type ), // type of data
 	.kms_level    (kbd_mouse_level  ),
+	.mouse2_btn   (mouse2_buttons   ), // port 2 mouse buttons (dual-mouse)
+	.kbd_mouse2_data (kbd_mouse2_data), // port 2 mouse direction data
+	.kbd_mouse2_type (kbd_mouse2_type), // port 2 type of data
+	.kms2_level   (kbd_mouse2_level ),
 	.pwr_led      (pwr_led          ), // power led
 	.fdd_led      (LED_USER         ),
 	.hdd_led      (ide_c_led        ),

--- a/hps_ext.v
+++ b/hps_ext.v
@@ -41,6 +41,12 @@ module hps_ext
 	output reg  [1:0] kbd_mouse_type,
 	output reg  [7:0] kbd_mouse_data,
 
+	// second mouse (port 2) - dual-mouse support
+	output reg  [2:0] mouse2_buttons,
+	output reg        kbd_mouse2_level,
+	output reg  [1:0] kbd_mouse2_type,
+	output reg  [7:0] kbd_mouse2_data,
+
 	input      [11:0] scr_hbl_l,
 	input      [11:0] scr_hbl_r,
 	input      [11:0] scr_hsize,
@@ -74,6 +80,7 @@ localparam EXT_CMD_MIN2 = 'h61;
 localparam EXT_CMD_MAX2 = 'h63;
 
 localparam UIO_MOUSE     = 'h04;
+localparam UIO_MOUSE2    = 'h07;
 localparam UIO_KEYBOARD  = 'h05;
 localparam UIO_KBD_OSD   = 'h06;
 localparam UIO_GET_VMODE = 'h2C;
@@ -145,6 +152,30 @@ always@(posedge clk_sys) begin
 								// wheel
 								kbd_mouse_data <= io_din[7:0];
 								kbd_mouse_level <= ~kbd_mouse_level; 
+							end
+					endcase
+
+				UIO_MOUSE2:
+					case(byte_cnt)
+						1: begin
+								kbd_mouse2_data <= io_din[7:0];
+								kbd_mouse2_type <= 0;
+								kbd_mouse2_level <= ~kbd_mouse2_level;
+							end
+						2: begin
+								// second byte contains movement data
+								kbd_mouse2_data <= io_din[7:0];
+								kbd_mouse2_type <= 1;
+								kbd_mouse2_level <= ~kbd_mouse2_level; 
+							end
+						3: begin
+								// third byte contains the buttons
+								mouse2_buttons <= io_din[2:0];
+							end
+						4: begin
+								// wheel
+								kbd_mouse2_data <= io_din[7:0];
+								kbd_mouse2_level <= ~kbd_mouse2_level; 
 							end
 					endcase
 

--- a/rtl/minimig.v
+++ b/rtl/minimig.v
@@ -205,6 +205,10 @@ module minimig
 	input 	     kms_level,
 	input   [1:0] kbd_mouse_type,
 	input   [7:0] kbd_mouse_data,
+	input   [2:0] mouse2_btn,  // port 2 mouse buttons (dual-mouse)
+	input 	     kms2_level,
+	input   [1:0] kbd_mouse2_type,
+	input   [7:0] kbd_mouse2_data,
 	output 	     pwr_led,     // power led
 	output 	     fdd_led,     // disk activity LED, active when DMA is on
 	output 	     hdd_led,
@@ -542,7 +546,11 @@ userio USERIO1
 	.mouse_btn(mouse_btn),
 	.kbd_mouse_type(kbd_mouse_type),
 	.kms_level(kms_level),
-	.kbd_mouse_data(kbd_mouse_data), 
+	.kbd_mouse_data(kbd_mouse_data),
+	.mouse2_btn(mouse2_btn),
+	.kbd_mouse2_type(kbd_mouse2_type),
+	.kms2_level(kms2_level),
+	.kbd_mouse2_data(kbd_mouse2_data),
 	.aud_mix(aud_mix),
 	.IO_ENA(IO_UIO),
 	.IO_STROBE(IO_STROBE),

--- a/rtl/userio.v
+++ b/rtl/userio.v
@@ -47,6 +47,10 @@ module userio
 	input             kms_level,
 	input       [1:0] kbd_mouse_type,
 	input       [7:0] kbd_mouse_data,
+	input       [2:0] mouse2_btn,        // port 2 mouse buttons (dual-mouse)
+	input             kms2_level,
+	input       [1:0] kbd_mouse2_type,
+	input       [7:0] kbd_mouse2_data,
 	output reg  [1:0] aud_mix,
 	input             IO_ENA,
 	input             IO_STROBE,
@@ -103,11 +107,15 @@ reg   [15:0] _sjoy2;        // synchronized joystick 2 signals
 reg   [15:0] _djoy2;        // synchronized joystick 2 signals
 reg   [15:0] potreg;        // POTGO write
 wire  [15:0] mouse0dat;     // mouse counters
+wire  [15:0] mouse1dat;     // port 2 real mouse counters (dual-mouse)
 reg   [15:0] dmouse0dat;    // docking mouse counters
 reg   [15:0] dmouse1dat;    // docking mouse counters
 wire         _mleft;        // left mouse button
 wire         _mthird;       // middle mouse button
 wire         _mright;       // right mouse buttons
+wire         _mleft2;       // port 2 left mouse button (dual-mouse)
+wire         _mthird2;      // port 2 middle mouse button
+wire         _mright2;      // port 2 right mouse button
 reg           joy1enable;   // joystick 1 enable (mouse/joy switch)
 wire         test_load;     // load test value to mouse counter
 wire  [15:0] test_data;     // mouse counter test value
@@ -183,9 +191,9 @@ always @ (posedge clk) begin
 		if (cd32pad & ~joy2_pin5) begin
 			potcap[3] <= cd32pad2_reg[7];
 		end else begin
-			potcap[3] <= _djoy2[5] & ~(potreg[15] & ~potreg[14]);
+			potcap[3] <= _mright2 & _djoy2[5] & ~(potreg[15] & ~potreg[14]);
 		end
-		potcap[2] <= joy2_pin5;
+		potcap[2] <= _mthird2 & joy2_pin5;
 
 		if(joy1enable & cd32pad & ~joy1_pin5) begin
 			potcap[1] <= cd32pad1_reg[7];
@@ -310,8 +318,8 @@ always @(*) begin
 		data_out[15:0] = {mouse0dat[15:10] + dmouse0dat[15:10],dmouse0dat[9:8],mouse0dat[7:2] + dmouse0dat[7:2],dmouse0dat[1:0]};
 	else if (reg_address_in[8:1]==JOY0DAT[8:1])//read port 1 mouse
 		data_out[15:0] = {mouse0dat[15:8] + dmouse0dat[15:8],mouse0dat[7:0] + dmouse0dat[7:0]};
-	else if (reg_address_in[8:1]==JOY1DAT[8:1])//read port 2 joystick
-		data_out[15:0] = dmouse1dat;
+	else if (reg_address_in[8:1]==JOY1DAT[8:1])//read port 2 joystick + real mouse (dual-mouse)
+		data_out[15:0] = {mouse1dat[15:8] + dmouse1dat[15:8], mouse1dat[7:0] + dmouse1dat[7:0]};
 	else if (reg_address_in[8:1]==POT0DAT[8:1])
 		data_out[15:0] = { pot0y, pot0x };
 	else if (reg_address_in[8:1]==POT1DAT[8:1])
@@ -330,7 +338,7 @@ end
 
 // assign fire outputs to cia A
 assign _fire0 = cd32pad && !cd32pad1_reg_load ? fire1_d : _sjoy1[4] & _mleft;
-assign _fire1 = cd32pad && !cd32pad2_reg_load ? fire2_d : _sjoy2[4];
+assign _fire1 = cd32pad && !cd32pad2_reg_load ? fire2_d : _sjoy2[4] & _mleft2;
 
 //JB: some trainers writes to JOYTEST register to reset current mouse counter
 assign test_load = reg_address_in[8:1]==JOYTEST[8:1] ? 1'b1 : 1'b0;
@@ -381,6 +389,45 @@ assign mouse0dat = {ycount, xcount};
 assign _mleft  = ~mouse_btn[0];
 assign _mright = ~mouse_btn[1];
 assign _mthird = ~mouse_btn[2];
+
+
+//// port 2 mouse (dual-mouse support) ////
+reg  [ 7:0] xcount1;
+reg  [ 7:0] ycount1;
+reg  [ 7:0] mouse1scr;
+
+// port 2 mouse counters (mirror of port 1; note: no JOYTEST reset for port 2)
+always @(posedge clk) begin
+	reg old_level;
+	reg wheel;
+
+	old_level <= kms2_level;
+
+	if(reset) begin
+		xcount1 <= 0;
+		ycount1 <= 0;
+		mouse1scr <= 0;
+		wheel <= 0;
+	end else if (old_level ^ kms2_level) begin
+		if(kbd_mouse2_type == 0) begin
+			wheel <= 0;
+			xcount1[7:0] <= xcount1[7:0] + kbd_mouse2_data;
+		end
+		if(kbd_mouse2_type == 1) begin
+			wheel <= 1;
+			if(wheel) mouse1scr <= mouse1scr + kbd_mouse2_data;
+			else ycount1[7:0] <= ycount1[7:0] + kbd_mouse2_data;
+		end
+	end
+end
+
+// output
+assign mouse1dat = {ycount1, xcount1};
+
+// port 2 mouse buttons
+assign _mleft2  = ~mouse2_btn[0];
+assign _mright2 = ~mouse2_btn[1];
+assign _mthird2 = ~mouse2_btn[2];
 
 
 //--------------------------------------------------------------------------------------


### PR DESCRIPTION
This feature relies on this pull request to be added to MiSTer Main:
https://github.com/MiSTer-devel/Main_MiSTer/pull/1220

Adds a genuine second quadrature mouse on Amiga controller port 2 (JOY1DAT), so two-player mouse titles (The Settlers, Lemmings) work. Until now port 2's data register was fed only by joystick-as-mouse quadrature emulation (dmouse1dat); there was no real mouse counter.

Userspace sends a new UIO_MOUSE2 (0x07) packet for the second mouse, mirroring UIO_MOUSE. The packet is decoded in hps_ext.v into a second strobed kbd_mouse2 channel + mouse2_buttons, threaded Minimig.sv -> minimig.v -> userio.v alongside the existing port-1 signals.

In userio.v:
- new mouse1 counter (xcount1/ycount1/mouse1scr) mirroring mouse0, fed by the kbd_mouse2 strobe; mouse1dat = {ycount1, xcount1}.
- JOY1DAT read now returns mouse1dat + dmouse1dat (mirrors JOY0DAT's mouse path); joystick-emu behavior is preserved when no real mouse is present since mouse1dat stays 0.
- port-2 mouse buttons: _fire1 gains & _mleft2; potcap[3] gains & _mright2; potcap[2] gains & _mthird2 (mirrors port-1 LMB/RMB/MMB). cd32pad paths are untouched.

A core that never receives UIO_MOUSE2 (single mouse, or other cores) behaves exactly as before.

Works with Lemmings and Settlers 1