### PR TITLE
Clarify supported HDF image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ By default up to 2 IDE devices are supported. For Secondary Master/Slave devices
 Removable/CD mode allows to hot swap CDs. Currently audio portion of CD isn't implemented (although playback commands should be accepted).
 
 ### How to make a new HDF (HDD Image)
+Only plain/raw HDF images are supported. WinUAE Dynamic HDF and Sparse File HDF formats are not supported.
+
 1) Create an empty HDF file of required size on PC (ideally fill it by 0 if possible).
 2) Copy it to MiSTer
 3) Mount it as HDF on OSD, and also mount some adf with HDToolBox (for example install3.2.adf from OS3.2)


### PR DESCRIPTION
Fixes #210.

This updates the README to clarify Minimig HDF image support based on maintainer guidance in the issue.

The documentation now makes clear that:

- simple HDF images are supported
- WinUAE Dynamic HDF images are not supported
- WinUAE Sparse File HDF images are not supported
- HDF images using both Dynamic and Sparse options are not supported

Changed file:

- "README.md"

No HDL, build files, project files, gameplay logic, or ROM definitions are changed.

Validation performed:

- confirmed the README wording matches maintainer guidance from issue #210
- "git diff --check"
- "git diff --cached --check"
- "git show --check HEAD"

No MiSTer hardware validation is required because this is documentation-only.