### PR TITLE
Add A2065 ZorroII Ethernet card emulation (LANCE Am7990)

### DIFF
--- a/Minimig.sdc
+++ b/Minimig.sdc
@@ -17,6 +17,25 @@ set_false_path -from {emu|minimig|USERIO1|ide_config*}
 set_false_path -from {emu|minimig|USERIO1|bootrom}
 set_false_path -from {emu|minimig|CPU1|halt}
 
+# A2065: the card's 68k side (clk_sys) reaches its DDR3 mailbox (DDRAM_CLK,
+# clk_114) over 2-FF level-detect CDC handshakes inside a2065_regfile and
+# a2065_ddram. Those are self-timed and need no multicycle exception. If the
+# fitter reports real violations across that boundary, add a targeted
+# set_false_path/set_max_delay derived from report_timing — do not guess.
+
+# yc_out chroma LUT: multicycle retained from the old bridge, where boardram BRAM
+# placement congestion pushed this path to -0.471ns. The flat-DDR3 design removes
+# that BRAM, so this exception may now be UNNECESSARY. Re-validate against the
+# merged fitter run (R3); keep only if report_timing still shows the path marginal.
+set_multicycle_path -from {yc_out|chroma_LUT_BURST[*]} \
+                    -to   {yc_out|phase[*].u[*]} -setup 2
+set_multicycle_path -from {yc_out|chroma_LUT_BURST[*]} \
+                    -to   {yc_out|phase[*].u[*]} -hold 1
+
+# emu PLL cross-clock: counter[1]→counter[0] marginal path
+set_multicycle_path -setup 2 -from [get_clocks "emu|pll|pll_inst|altera_pll_i|cyclonev_pll|counter\[1\].output_counter|divclk"] -to [get_clocks "emu|pll|pll_inst|altera_pll_i|cyclonev_pll|counter\[0\].output_counter|divclk"]
+set_multicycle_path -hold 1 -from [get_clocks "emu|pll|pll_inst|altera_pll_i|cyclonev_pll|counter\[1\].output_counter|divclk"] -to [get_clocks "emu|pll|pll_inst|altera_pll_i|cyclonev_pll|counter\[0\].output_counter|divclk"]
+
 #these constraints aren't really correct, but help fitting.
 #28MHz pixel clock might be affected when scandoubler fx is used.
 set_multicycle_path -to {*Hq2x*} -setup 2

--- a/Minimig.sv
+++ b/Minimig.sv
@@ -283,6 +283,8 @@ wire        ramshared;
 
 wire [7:0] toccata_base;
 wire toccata_ena;
+wire a2065_ena;
+wire [7:0] a2065_base;
 
 cpu_wrapper cpu_wrapper
 (
@@ -318,6 +320,8 @@ cpu_wrapper cpu_wrapper
 	.bootrom      (bootrom         ),
 
 	.toccata_ena  (toccata_ena     ),
+	.a2065_ena    (a2065_ena       ),
+	.a2065_base   (a2065_base      ),
 	.toccata_base (toccata_base    ),
 	
 	.ramsel       (ram_sel         ),
@@ -379,8 +383,7 @@ sdram_ctrl ram1
 
 wire [15:0] ram_dout2;
 wire        ram_ready2;
-wire  [7:0] DDRAM_BE_S;
-   
+
 ddram_ctrl ram2
 (
 	.sysclk       (clk_114         ),
@@ -400,6 +403,16 @@ ddram_ctrl ram2
 	.DDRAM_BE     (DDRAM_BE        ),
 	.DDRAM_WE     (DDRAM_WE        ),
 
+	.mem2_address      (a2065_mem_address),
+	.mem2_burstcount   (a2065_mem_burstcount),
+	.mem2_read         (a2065_mem_read),
+	.mem2_readdata     (a2065_mem_readdata),
+	.mem2_readdatavalid(a2065_mem_readdatavalid),
+	.mem2_writedata    (a2065_mem_writedata),
+	.mem2_byteenable   (a2065_mem_byteenable),
+	.mem2_write        (a2065_mem_write),
+	.mem2_waitrequest  (a2065_mem_waitrequest),
+
 	.cpuWR        (ram_din         ),
 	.cpuAddr      (ram_addr        ),
 	.cpuU         (ram_uds         ),
@@ -410,6 +423,19 @@ ddram_ctrl ram2
 	.ramshared    (ramshared       ),
 	.ramready     (ram_ready2      )
 );
+
+////////////////////////////  A2065 ETHERNET  ///////////////////////////////
+//
+// The card is self-contained inside minimig; all that surfaces here is its
+// memory port, which shares the core's DDR3 interface with the fast-RAM
+// controller above. Fast RAM has priority: it carries every 68k access to
+// Zorro RAM, while the card touches DDR3 rarely and can wait.
+
+wire [28:0] a2065_mem_address;
+wire [7:0]  a2065_mem_burstcount, a2065_mem_byteenable;
+wire        a2065_mem_read, a2065_mem_write;
+wire [63:0] a2065_mem_writedata, a2065_mem_readdata;
+wire        a2065_mem_readdatavalid, a2065_mem_waitrequest;
 
 wire [15:0] fastchip_dout;
 wire        fastchip_sel;
@@ -616,6 +642,8 @@ minimig minimig
 	//toccata soundcard
 	.toccata_ena  (toccata_ena),
 	.toccata_base (toccata_base),
+	.a2065_ena  (a2065_ena),
+	.a2065_base (a2065_base),
 	.toccata_aud_left (toccata_aud_left),
 	.toccata_aud_right(toccata_aud_right),
 	
@@ -633,7 +661,18 @@ minimig minimig
 	.ide_write    (ide_wr           ),
 	.ide_writedata(ide_dout         ),
 	.ide_read     (ide_rd           ),
-	.ide_readdata (ide_c_readdata   )
+	.ide_readdata (ide_c_readdata   ),
+
+	.a2065_clk_ddr(DDRAM_CLK),
+	.a2065_mem_address(a2065_mem_address),
+	.a2065_mem_burstcount(a2065_mem_burstcount),
+	.a2065_mem_read(a2065_mem_read),
+	.a2065_mem_readdata(a2065_mem_readdata),
+	.a2065_mem_readdatavalid(a2065_mem_readdatavalid),
+	.a2065_mem_writedata(a2065_mem_writedata),
+	.a2065_mem_byteenable(a2065_mem_byteenable),
+	.a2065_mem_write(a2065_mem_write),
+	.a2065_mem_waitrequest(a2065_mem_waitrequest)
 );
 
 // power led control

--- a/files.qip
+++ b/files.qip
@@ -7,6 +7,11 @@ set_global_assignment -name QIP_FILE rtl/gayle.qip
 set_global_assignment -name QIP_FILE rtl/paula.qip
 set_global_assignment -name QIP_FILE rtl/denise.qip
 set_global_assignment -name QIP_FILE rtl/fpga-toccata/toccata.qip
+set_global_assignment -name VERILOG_FILE rtl/A2065/a2065.v
+set_global_assignment -name VERILOG_FILE rtl/A2065/a2065_regfile.v
+set_global_assignment -name VERILOG_FILE rtl/A2065/a2065_ddram.v
+set_global_assignment -name VERILOG_FILE rtl/A2065/a2065_ddram_arbiter.v
+set_global_assignment -name VERILOG_FILE rtl/A2065/a2065_ddr3_mailbox.v
 set_global_assignment -name VERILOG_FILE rtl/gary.v
 set_global_assignment -name VERILOG_FILE rtl/rtg.v
 set_global_assignment -name VERILOG_FILE rtl/akiko.v

--- a/rtl/A2065/a2065.v
+++ b/rtl/A2065/a2065.v
@@ -1,0 +1,168 @@
+/*
+ * a2065.v — Commodore A2065 ZorroII Ethernet card.
+ *
+ * Everything the card needs on the FPGA side lives in here: the LANCE chip
+ * registers, the boardram window, and the mailbox that carries both to the
+ * host over DDR3. The rest of the core sees only the 68k bus, an interrupt,
+ * and one memory port.
+ *
+ * The host half — the Am7990 controller itself, the descriptor rings and the
+ * network socket — runs on the HPS, in Main under support/minimig/.
+ *
+ *   68k side (clk_sys)          this module                host (via DDR3)
+ *   ------------------          ----------                 ---------------
+ *   $EAxxxx chip regs   ---->   a2065_regfile     ---->     CMD ring
+ *                               (CSR reads answered from a shadow the host
+ *                                keeps current, so reads never stall)
+ *   $EA8000 boardram    <-->    a2065_ddram       <-->      flat DDR3 window
+ *                               (DTACK stretched for the DDR3 round trip)
+ *   INT2                <----   a2065_ddr3_mailbox <----    interrupt state
+ *
+ * Register writes are posted to a ring and the bus released as soon as the
+ * entry lands, so the Amiga never waits on host scheduling. Only the boardram
+ * path stretches DTACK, and only for FPGA-side work.
+ */
+
+module a2065 (
+    // ── 68k bus, Amiga clock domain ──────────────────────────────────────
+    input  wire        clk_sys,
+    input  wire        rst_n_sys,
+
+    input  wire [23:1] cpu_addr,
+    input  wire [15:0] cpu_data_in,
+    output wire [15:0] cpu_data_out,   // zero unless this card is addressed
+    input  wire        cpu_rw,         // 1 = read
+    input  wire        cpu_as_n,
+    input  wire        cpu_uds_n,
+    input  wire        cpu_lds_n,
+    input  wire        sel,            // $EAxxxx decode from gary
+    output wire        nrdy,           // stretch DTACK
+    output wire        int2,           // to Paula, already synchronised here
+
+    input  wire [7:0]  card_base,      // autoconfig base address
+    input  wire        card_configured,
+
+    // ── DDR3, memory clock domain ────────────────────────────────────────
+    input  wire        clk_ddr,
+    output wire [28:0] mem_address,
+    output wire [7:0]  mem_burstcount,
+    output wire        mem_read,
+    input  wire [63:0] mem_readdata,
+    input  wire        mem_readdatavalid,
+    output wire [63:0] mem_writedata,
+    output wire [7:0]  mem_byteenable,
+    output wire        mem_write,
+    input  wire        mem_waitrequest
+);
+
+    // ── chip registers ↔ mailbox ─────────────────────────────────────────
+    wire        cmd_pending, cmd_clear;
+    wire [6:0]  cmd_rap;
+    wire [15:0] cmd_data;
+    wire [15:0] csr0, csr1, csr2, csr3;
+
+    // ── boardram window ↔ mailbox ────────────────────────────────────────
+    wire        bram_req_valid, bram_req_rw, bram_req_ack, bram_resp_valid;
+    wire [13:0] bram_req_addr;
+    wire [15:0] bram_req_wdata, bram_resp_data;
+    wire [1:0]  bram_req_be;
+
+    wire [15:0] regs_dout, bram_dout;
+    wire        regs_nrdy, bram_nrdy;
+
+    // Both halves drive zero unless addressed, so the card presents a single
+    // value to the core's read mux.
+    assign cpu_data_out = regs_dout | bram_dout;
+    assign nrdy         = regs_nrdy | bram_nrdy;
+
+    a2065_regfile regfile (
+        .clk            (clk_sys),
+        .rst_n          (rst_n_sys),
+        .cpu_addr       ({cpu_addr, 1'b0}),
+        .cpu_rw         (cpu_rw),
+        .cpu_as_n       (cpu_as_n),
+        .cpu_ds_n       (cpu_uds_n & cpu_lds_n),
+        .cpu_data_in    (cpu_data_in),
+        .cpu_data_out   (regs_dout),
+        .regs_nrdy      (regs_nrdy),
+        .card_base      (card_base),
+        .card_configured(card_configured),
+        .cmd_pending    (cmd_pending),
+        .cmd_rap        (cmd_rap),
+        .cmd_data       (cmd_data),
+        .cmd_clear      (cmd_clear),
+        .csr0_in        (csr0),
+        .csr1_in        (csr1),
+        .csr2_in        (csr2),
+        .csr3_in        (csr3)
+    );
+
+    a2065_ddram boardram (
+        .clk_sys              (clk_sys),
+        .rst_n_sys            (rst_n_sys),
+        .cpu_addr             (cpu_addr),
+        .cpu_data_in          (cpu_data_in),
+        .cpu_data_out         (bram_dout),
+        .cpu_rw               (cpu_rw),
+        .cpu_as_n             (cpu_as_n),
+        .cpu_uds_n            (cpu_uds_n),
+        .cpu_lds_n            (cpu_lds_n),
+        .sel                  (sel),
+        .nrdy                 (bram_nrdy),
+        .bram_req_valid       (bram_req_valid),
+        .bram_req_addr        (bram_req_addr),
+        .bram_req_wdata       (bram_req_wdata),
+        .bram_req_rw          (bram_req_rw),
+        .bram_req_be          (bram_req_be),
+        .bram_req_ack_audio   (bram_req_ack),
+        .bram_resp_valid_audio(bram_resp_valid),
+        .bram_resp_data_audio (bram_resp_data)
+    );
+
+    wire int2_ddr;
+
+    a2065_ddr3_mailbox mailbox (
+        .clk              (clk_ddr),
+        .rst_n            (rst_n_sys),
+
+        .cmd_pending      (cmd_pending),
+        .cmd_rap          (cmd_rap),
+        .cmd_data         (cmd_data),
+        .cmd_clear        (cmd_clear),
+
+        .csr0_out         (csr0),
+        .csr1_out         (csr1),
+        .csr2_out         (csr2),
+        .csr3_out         (csr3),
+        .a2065_int2       (int2_ddr),
+
+        .bram_req_valid   (bram_req_valid),
+        .bram_req_addr    (bram_req_addr),
+        .bram_req_wdata   (bram_req_wdata),
+        .bram_req_rw      (bram_req_rw),
+        .bram_req_be      (bram_req_be),
+        .bram_req_ack     (bram_req_ack),
+        .bram_resp_valid  (bram_resp_valid),
+        .bram_resp_data   (bram_resp_data),
+
+        .avl_address      (mem_address),
+        .avl_burstcount   (mem_burstcount),
+        .avl_read         (mem_read),
+        .avl_readdata     (mem_readdata),
+        .avl_readdatavalid(mem_readdatavalid),
+        .avl_writedata    (mem_writedata),
+        .avl_byteenable   (mem_byteenable),
+        .avl_write        (mem_write),
+        .avl_waitrequest  (mem_waitrequest)
+    );
+
+    // The interrupt is raised in the memory clock domain and consumed in the
+    // Amiga's, so synchronise it here rather than leaving that to the caller.
+    reg int2_s1, int2_s2;
+    always @(posedge clk_sys) begin
+        int2_s1 <= int2_ddr;
+        int2_s2 <= int2_s1;
+    end
+    assign int2 = int2_s2;
+
+endmodule

--- a/rtl/A2065/a2065_ddr3_mailbox.v
+++ b/rtl/A2065/a2065_ddr3_mailbox.v
@@ -1,0 +1,397 @@
+/*
+ * a2065_ddr3_mailbox.v
+ *
+ * DDR3 mailbox adapter for A2065 (Phase 2 — doorbell architecture).
+ *
+ * Runs entirely in the core's DDR3 clock domain (DDRAM_CLK, ~114 MHz).
+ * Handles three functions:
+ *
+ *   1. CMD doorbell: regfile raises cmd_pending → mailbox writes CMD to
+ *      DDR3 for ARM daemon → pulses cmd_clear.  No DTACK stretch for
+ *      reads/RAP writes — only back-pressure on overlapping RDP writes.
+ *
+ *   2. Boardram DDR3 window: 68k accesses boardram at card+0x8000 via
+ *      DTACK-stretched DDR3 read/write.  Request arrives via async
+ *      handshake from clk_sys; FSM performs direct DDR3 access.
+ *
+ *   3. CSR shadow + INT state poll: periodically reads CSR_SHADOW and
+ *      INT_STATE from DDR3 (written by ARM daemon).  CSR values feed
+ *      back to regfile for 68k zero-latency reads.  INT_STATE drives
+ *      the a2065_int2 output.
+ *
+ * Priority: CMD doorbell > boardram window > CSR/INT poll.
+ */
+
+module a2065_ddr3_mailbox (
+    input  wire         clk,
+    input  wire         rst_n,
+
+    input  wire         cmd_pending,
+    input  wire  [6:0]  cmd_rap,
+    input  wire  [15:0] cmd_data,
+    output reg          cmd_clear,
+
+    output reg  [15:0]  csr0_out,
+    output reg  [15:0]  csr1_out,
+    output reg  [15:0]  csr2_out,
+    output reg  [15:0]  csr3_out,
+    output reg          a2065_int2,
+
+    input  wire         bram_req_valid,
+    input  wire  [13:0] bram_req_addr,
+    input  wire  [15:0] bram_req_wdata,
+    input  wire         bram_req_rw,
+    input  wire  [1:0]  bram_req_be,
+    output reg          bram_req_ack,
+    output reg          bram_resp_valid,
+    output reg  [15:0]  bram_resp_data,
+
+    output reg  [28:0]  avl_address,
+    output reg  [7:0]   avl_burstcount,
+    output reg          avl_read,
+    input  wire [63:0]  avl_readdata,
+    input  wire         avl_readdatavalid,
+    output reg  [63:0]  avl_writedata,
+    output reg  [7:0]   avl_byteenable,
+    output reg          avl_write,
+    input  wire         avl_waitrequest
+);
+
+    localparam DDR3_BASE = 29'h03FE0000;
+
+    localparam AV_CMD          = 29'h1000;
+    /* Register writes are posted into a ring rather than a single slot, and
+     * the bus is released as soon as the entry reaches DDR3 — the host is
+     * never waited on. Waiting for host software here would deadlock: Main is
+     * single-threaded, and while it sits in its IDE handler waiting for the
+     * Amiga, the Amiga would be sitting on a stretched DTACK waiting for Main.
+     * 256 entries is far more than the 68k can post while Main is busy
+     * elsewhere. */
+    localparam AV_CMD_WPTR     = 29'h1001;
+    localparam AV_CMD_RING     = 29'h1100;
+    localparam CMD_RING_BITS   = 8;
+    localparam AV_CSR          = 29'h1002;
+    localparam AV_INT          = 29'h1003;
+
+    localparam S_IDLE          = 4'd0;
+    localparam S_CMD_WR_W      = 4'd1;
+    localparam S_CMD_DONE      = 4'd2;
+
+    localparam S_BR_CAPTURE    = 4'd3;
+    localparam S_BR_READ_W     = 4'd4;
+    localparam S_BR_READ_D     = 4'd5;
+    localparam S_BR_WRITE_W    = 4'd6;
+    localparam S_BR_DONE       = 4'd7;
+
+    localparam S_CSR_RD_W      = 4'd8;
+    localparam S_CSR_RD_D      = 4'd9;
+    localparam S_INT_RD_W      = 4'd10;
+    localparam S_INT_RD_D      = 4'd11;
+
+    localparam S_BR_RMW_RD_W   = 4'd12;
+    localparam S_BR_RMW_RD_D   = 4'd13;
+
+    localparam S_CMD_WPTR_W    = 4'd14;
+    localparam S_WPTR_INIT     = 4'd15;
+
+    reg [3:0] state;
+    reg [31:0] cmd_wr_idx;
+    reg        wptr_published;
+
+    reg  [7:0] poll_div;
+
+    reg  [13:0] br_addr;
+    reg  [15:0] br_wdata;
+    reg         br_rw;
+    reg  [1:0]  br_lane;
+    reg  [1:0]  br_be;
+
+    wire [28:0] br_ddr3_addr = DDR3_BASE + {17'b0, br_addr[13:2]};
+
+    /* Boardram writes use read-modify-write: the f2sdram2 port has only
+     * ever been exercised with full-word (be=0xFF) writes (audio, PAL,
+     * old DDR3 mailbox).  Partial byteenable writes are unproven and the
+     * single 16-bit lane would otherwise zero its 3 line-neighbours.  So
+     * read the 64-bit line, merge the target lane, write the whole line
+     * back with be=0xFF. */
+
+    reg bram_req_valid_s, bram_req_valid_s1;
+    reg [13:0] bram_req_addr_s;
+    reg [15:0] bram_req_wdata_s;
+    reg        bram_req_rw_s;
+    reg [1:0]  bram_req_be_s;
+
+    always @(posedge clk) begin
+        bram_req_valid_s  <= bram_req_valid;
+        bram_req_valid_s1 <= bram_req_valid_s;
+
+        bram_req_addr_s   <= bram_req_addr;
+        bram_req_wdata_s  <= bram_req_wdata;
+        bram_req_rw_s     <= bram_req_rw;
+        bram_req_be_s     <= bram_req_be;
+    end
+
+    wire bram_req_active = bram_req_valid_s1;
+
+    reg cmd_pending_s, cmd_pending_s1;
+    reg [6:0]  cmd_rap_s;
+    reg [15:0] cmd_data_s;
+
+    always @(posedge clk) begin
+        cmd_pending_s  <= cmd_pending;
+        cmd_pending_s1 <= cmd_pending_s;
+        cmd_rap_s      <= cmd_rap;
+        cmd_data_s     <= cmd_data;
+    end
+
+    wire cmd_active = cmd_pending_s1;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state           <= S_IDLE;
+            avl_address     <= 0;
+            avl_burstcount  <= 1;
+            avl_read        <= 0;
+            avl_write       <= 0;
+            avl_writedata   <= 0;
+            avl_byteenable  <= 8'hFF;
+            poll_div        <= 0;
+            cmd_clear       <= 0;
+            csr0_out        <= 0;
+            csr1_out        <= 0;
+            csr2_out        <= 0;
+            csr3_out        <= 0;
+            a2065_int2      <= 0;
+            bram_req_ack    <= 0;
+            bram_resp_valid <= 0;
+            bram_resp_data  <= 0;
+            br_lane         <= 0;
+            br_be           <= 2'b11;
+            cmd_wr_idx      <= 32'd0;
+            wptr_published  <= 1'b0;
+        end else begin
+            avl_read        <= 0;
+            avl_write       <= 0;
+
+            /* cmd_clear / bram_req_ack / bram_resp_valid answer a requester in
+             * a slower clock domain (clk_sys), so they are held until that
+             * requester withdraws its request rather than pulsed for a single
+             * cycle. A one-cycle pulse here is ~9ns and the far side samples
+             * every ~35ns, so it would simply be missed and both sides would
+             * wait forever — the request lines are already levels for the same
+             * reason. Holding them makes the handshake independent of the
+             * ratio between the two clocks. */
+            if (!cmd_active) cmd_clear <= 0;
+            if (!bram_req_active) begin
+                bram_req_ack    <= 0;
+                bram_resp_valid <= 0;
+            end
+
+            poll_div <= poll_div + 1'b1;
+
+            case (state)
+            S_IDLE: begin
+                if (!wptr_published) begin
+                    // Publish the index once after reset so the host never
+                    // reads a stale value left in DDR3 by a previous session.
+                    avl_address    <= DDR3_BASE + AV_CMD_WPTR;
+                    avl_writedata  <= 64'd0;
+                    avl_byteenable <= 8'hFF;
+                    avl_burstcount <= 1;
+                    avl_write      <= 1;
+                    state          <= S_WPTR_INIT;
+                end else if (cmd_active && !cmd_clear) begin
+                    avl_address    <= DDR3_BASE + AV_CMD_RING
+                                      + {21'b0, cmd_wr_idx[CMD_RING_BITS-1:0]};
+                    avl_writedata  <= {39'b0, cmd_data_s, cmd_rap_s, 1'b1};
+                    avl_byteenable <= 8'hFF;
+                    avl_burstcount <= 1;
+                    avl_write      <= 1;
+                    state          <= S_CMD_WR_W;
+                end else if (bram_req_active && !bram_req_ack) begin
+                    br_addr      <= bram_req_addr_s;
+                    br_wdata     <= bram_req_wdata_s;
+                    br_rw        <= bram_req_rw_s;
+                    br_be        <= bram_req_be_s;
+                    br_lane      <= bram_req_addr_s[1:0];
+                    bram_req_ack <= 1'b1;
+                    state        <= S_BR_CAPTURE;
+                end else if (&poll_div[5:0]) begin
+                    avl_address    <= DDR3_BASE + AV_CSR;
+                    avl_burstcount <= 1;
+                    avl_read       <= 1;
+                    state          <= S_CSR_RD_W;
+                end
+            end
+
+            S_CMD_WR_W: begin
+                if (!avl_waitrequest) begin
+                    // Entry is in DDR3; publish the advanced write index so the
+                    // host can see it.
+                    cmd_wr_idx     <= cmd_wr_idx + 1'b1;
+                    avl_address    <= DDR3_BASE + AV_CMD_WPTR;
+                    avl_writedata  <= {32'b0, cmd_wr_idx + 1'b1};
+                    avl_byteenable <= 8'hFF;
+                    avl_burstcount <= 1;
+                    avl_write      <= 1;
+                    state          <= S_CMD_WPTR_W;
+                end else begin
+                    avl_write <= 1;
+                end
+            end
+
+            S_WPTR_INIT: begin
+                if (!avl_waitrequest) begin
+                    wptr_published <= 1'b1;
+                    state          <= S_IDLE;
+                end else begin
+                    avl_write <= 1;
+                end
+            end
+
+            S_CMD_WPTR_W: begin
+                if (!avl_waitrequest) begin
+                    // Index published — release the 68k now. The host reads
+                    // the ring in its own time; nothing here waits on it.
+                    cmd_clear <= 1'b1;
+                    state     <= S_CMD_DONE;
+                end else begin
+                    avl_write <= 1;
+                end
+            end
+
+            S_CMD_DONE: begin
+                cmd_clear <= 1'b1;
+                if (!cmd_pending_s1) begin
+                    cmd_clear <= 1'b0;
+                    state     <= S_IDLE;
+                end
+            end
+
+            S_BR_CAPTURE: begin
+                // Both read and write begin by reading the 64-bit line.
+                avl_address    <= br_ddr3_addr;
+                avl_burstcount <= 1;
+                avl_read       <= 1;
+                state          <= br_rw ? S_BR_RMW_RD_W : S_BR_READ_W;
+            end
+
+            S_BR_READ_W: begin
+                if (!avl_waitrequest) begin
+                    avl_read <= 0;
+                    state    <= S_BR_READ_D;
+                end else begin
+                    avl_read <= 1;
+                end
+            end
+
+            S_BR_READ_D: begin
+                if (avl_readdatavalid) begin
+                    case (br_lane)
+                    2'd0: bram_resp_data <= avl_readdata[15:0];
+                    2'd1: bram_resp_data <= avl_readdata[31:16];
+                    2'd2: bram_resp_data <= avl_readdata[47:32];
+                    2'd3: bram_resp_data <= avl_readdata[63:48];
+                    endcase
+                    bram_resp_valid <= 1'b1;
+                    state           <= S_BR_DONE;
+                end
+            end
+
+            S_BR_WRITE_W: begin
+                if (!avl_waitrequest) begin
+                    bram_resp_valid <= 1'b1;
+                    state           <= S_BR_DONE;
+                end else begin
+                    avl_write <= 1;
+                end
+            end
+
+            S_BR_DONE: begin
+                state <= S_IDLE;
+            end
+
+            S_BR_RMW_RD_W: begin
+                if (!avl_waitrequest) begin
+                    avl_read <= 0;
+                    state    <= S_BR_RMW_RD_D;
+                end else begin
+                    avl_read <= 1;
+                end
+            end
+
+            S_BR_RMW_RD_D: begin
+                if (avl_readdatavalid) begin
+                    // Merge only the enabled bytes of the target lane (br_be[1]
+                    // = high byte / UDS, br_be[0] = low byte / LDS); keep the
+                    // read-back bytes elsewhere so byte writes don't clobber
+                    // their pair or the 3 line-neighbours.
+                    case (br_lane)
+                    2'd0: avl_writedata <= {avl_readdata[63:16],
+                            br_be[1] ? br_wdata[15:8] : avl_readdata[15:8],
+                            br_be[0] ? br_wdata[7:0]  : avl_readdata[7:0]};
+                    2'd1: avl_writedata <= {avl_readdata[63:32],
+                            br_be[1] ? br_wdata[15:8] : avl_readdata[31:24],
+                            br_be[0] ? br_wdata[7:0]  : avl_readdata[23:16],
+                            avl_readdata[15:0]};
+                    2'd2: avl_writedata <= {avl_readdata[63:48],
+                            br_be[1] ? br_wdata[15:8] : avl_readdata[47:40],
+                            br_be[0] ? br_wdata[7:0]  : avl_readdata[39:32],
+                            avl_readdata[31:0]};
+                    2'd3: avl_writedata <= {
+                            br_be[1] ? br_wdata[15:8] : avl_readdata[63:56],
+                            br_be[0] ? br_wdata[7:0]  : avl_readdata[55:48],
+                            avl_readdata[47:0]};
+                    endcase
+                    avl_address    <= br_ddr3_addr;
+                    avl_byteenable <= 8'hFF;
+                    avl_burstcount <= 1;
+                    avl_write      <= 1;
+                    state          <= S_BR_WRITE_W;
+                end
+            end
+
+            S_CSR_RD_W: begin
+                if (!avl_waitrequest) begin
+                    avl_read <= 0;
+                    state    <= S_CSR_RD_D;
+                end else begin
+                    avl_read <= 1;
+                end
+            end
+
+            S_CSR_RD_D: begin
+                if (avl_readdatavalid) begin
+                    csr0_out <= avl_readdata[15:0];
+                    csr1_out <= avl_readdata[31:16];
+                    csr2_out <= avl_readdata[47:32];
+                    csr3_out <= avl_readdata[63:48];
+                    avl_address    <= DDR3_BASE + AV_INT;
+                    avl_burstcount <= 1;
+                    avl_read       <= 1;
+                    state          <= S_INT_RD_W;
+                end
+            end
+
+            S_INT_RD_W: begin
+                if (!avl_waitrequest) begin
+                    avl_read <= 0;
+                    state    <= S_INT_RD_D;
+                end else begin
+                    avl_read <= 1;
+                end
+            end
+
+            S_INT_RD_D: begin
+                if (avl_readdatavalid) begin
+                    a2065_int2 <= avl_readdata[0];
+                    state      <= S_IDLE;
+                end
+            end
+
+            default: state <= S_IDLE;
+            endcase
+        end
+    end
+
+endmodule

--- a/rtl/A2065/a2065_ddram.v
+++ b/rtl/A2065/a2065_ddram.v
@@ -1,0 +1,151 @@
+/*
+ * a2065_ddram.v
+ *
+ * 68k boardram DDR3 window — clk_sys interface module.
+ *
+ * Handles the 68k bus side of boardram access: address decode, request
+ * latch, DTACK stretch, and CDC handshake with the DDRAM_CLK mailbox
+ * FSM that performs the actual DDR3 read/write.
+ *
+ * Port A (68k bus, clk_sys):
+ *   - sel + cpu_addr[15] selects boardram at card+0x8000
+ *   - DTACK-stretched: nrdy asserted until DDR3 response arrives
+ *   - cpu_data_out driven on read completion
+ *
+ * The DDRAM_CLK FSM (in a2065_ddr3_mailbox) sees the request via CDC,
+ * performs DDR3 access, and signals completion back via CDC.
+ */
+
+module a2065_ddram (
+    input  wire         clk_sys,
+    input  wire         rst_n_sys,
+
+    input  wire [23:1]  cpu_addr,
+    input  wire [15:0]  cpu_data_in,
+    output wire [15:0]  cpu_data_out,
+    input  wire         cpu_rw,      // 68k R/W: 1=read, 0=write
+    input  wire         cpu_as_n,    // address strobe (active low)
+    input  wire         cpu_uds_n,   // upper data strobe (active low) — even byte D[15:8]
+    input  wire         cpu_lds_n,   // lower data strobe (active low) — odd byte  D[7:0]
+    input  wire         sel,
+    output wire         nrdy,
+
+    output reg          bram_req_valid,
+    output reg  [13:0]  bram_req_addr,
+    output reg  [15:0]  bram_req_wdata,
+    output reg          bram_req_rw,
+    output reg  [1:0]   bram_req_be,   // byte enables {high=UDS, low=LDS}
+
+    input  wire         bram_req_ack_audio,
+    input  wire         bram_resp_valid_audio,
+    input  wire [15:0]  bram_resp_data_audio
+);
+
+    // Qualify the access with AS+DS like a2065_regfile does: only capture
+    // when the strobes are asserted, so the direction (cpu_rw) and write
+    // data (cpu_data_in) are valid.  Keying off raw sel during the address
+    // phase captured before hwr/lwr/data were valid.  DS deasserts between
+    // bus cycles, giving a clean NR_DONE->NR_IDLE separation (no edge detect).
+    wire cpu_ds_n = cpu_uds_n & cpu_lds_n;   // any strobe asserted
+    wire sel_br   = sel && cpu_addr[15] && !cpu_as_n && !cpu_ds_n;
+    wire is_write = ~cpu_rw;
+    wire [1:0] req_be = {~cpu_uds_n, ~cpu_lds_n};
+    wire [13:0] word_idx = cpu_addr[14:1];
+
+    reg  [15:0] rd_data;
+    // Gate the read data onto the shared CPU data bus only while this card's
+    // boardram is the read target, so the held value can't corrupt the OR-mux
+    // for other peripherals' reads.
+    assign cpu_data_out = (sel && cpu_addr[15] && cpu_rw) ? rd_data : 16'h0000;
+
+    reg  sys_req;
+    reg  sys_got_resp;
+
+    reg  ack_sync0, ack_sync1;
+    reg  rv_sync0, rv_sync1;
+    reg [15:0] rd_sync0, rd_sync1;
+
+    reg  [1:0] nrdy_state;
+    localparam NR_IDLE  = 2'd0;
+    localparam NR_WAIT  = 2'd1;
+    localparam NR_DONE  = 2'd2;
+
+    always @(posedge clk_sys or negedge rst_n_sys) begin
+        if (!rst_n_sys) begin
+            sys_req       <= 1'b0;
+            sys_got_resp  <= 1'b0;
+            rd_data       <= 16'h0000;
+            bram_req_valid <= 1'b0;
+            bram_req_addr  <= 0;
+            bram_req_wdata <= 0;
+            bram_req_rw    <= 1'b0;
+            bram_req_be    <= 2'b11;
+            ack_sync0  <= 1'b0;
+            ack_sync1  <= 1'b0;
+            rv_sync0   <= 1'b0;
+            rv_sync1   <= 1'b0;
+            rd_sync0   <= 16'd0;
+            rd_sync1   <= 16'd0;
+        end else begin
+            sys_got_resp <= 1'b0;
+
+            ack_sync0 <= bram_req_ack_audio;
+            ack_sync1 <= ack_sync0;
+
+            rv_sync0 <= bram_resp_valid_audio;
+            rv_sync1 <= rv_sync0;
+
+            rd_sync0 <= bram_resp_data_audio;
+            rd_sync1 <= rd_sync0;
+
+            /* The request is withdrawn on the response, not on the capture
+             * ack: the mailbox holds its reply lines until it sees the request
+             * drop, so dropping it any earlier would retire the handshake
+             * before the read data had been taken. bram_req_ack only reports
+             * that the request was picked up. */
+            if (sys_req && rv_sync1) begin
+                sys_req        <= 1'b0;
+                bram_req_valid <= 1'b0;
+            end
+
+            if (rv_sync1) begin
+                sys_got_resp <= 1'b1;
+                rd_data <= rd_sync1;
+            end
+
+            if (sel_br && !sys_req && !sys_got_resp && nrdy_state == NR_IDLE) begin
+                bram_req_addr  <= word_idx;
+                bram_req_wdata <= cpu_data_in;
+                bram_req_rw    <= is_write;
+                bram_req_be    <= req_be;
+                bram_req_valid <= 1'b1;
+                sys_req        <= 1'b1;
+            end
+        end
+    end
+
+    always @(posedge clk_sys or negedge rst_n_sys) begin
+        if (!rst_n_sys) begin
+            nrdy_state <= NR_IDLE;
+        end else begin
+            case (nrdy_state)
+            NR_IDLE: begin
+                if (sel_br && !sys_req && !sys_got_resp)
+                    nrdy_state <= NR_WAIT;
+            end
+            NR_WAIT: begin
+                if (rv_sync1)
+                    nrdy_state <= NR_DONE;
+            end
+            NR_DONE: begin
+                if (!sel_br)
+                    nrdy_state <= NR_IDLE;
+            end
+            default: nrdy_state <= NR_IDLE;
+            endcase
+        end
+    end
+
+    assign nrdy = (nrdy_state == NR_WAIT);
+
+endmodule

--- a/rtl/A2065/a2065_ddram_arbiter.v
+++ b/rtl/A2065/a2065_ddram_arbiter.v
@@ -1,0 +1,161 @@
+/*
+ * a2065_ddram_arbiter.v
+ *
+ * Two-master Avalon-MM arbiter for the core's DDR3 port (the emu DDRAM_*
+ * interface).  Master 0 is the Minimig fast-RAM controller; master 1 is the
+ * A2065 DDR3 mailbox.
+ *
+ * Fixed priority, master 0 wins.  m0 carries every 68k fast-RAM access, so it
+ * must never be made to wait on the A2065: a stalled fast-RAM path hangs the
+ * Amiga, while a stalled mailbox only delays a network register poll by a few
+ * cycles.  m1 issues one single-beat transfer at a time and polls at a low
+ * rate, so it takes the gaps between m0's bursts and loses nothing in practice.
+ *
+ * Arbitration is per burst, decided when a burst starts and held until it
+ * completes, since Avalon gives no way to interleave two masters' beats on one
+ * slave.  Reads and writes complete differently:
+ *
+ *   write burst  done after burstcount beats have been accepted (!waitrequest)
+ *   read burst   done after burstcount beats have returned (readdatavalid)
+ *
+ * The single-beat case needs care: the start of a burst and its first accepted
+ * beat happen in the same cycle, so that beat is counted at the point the
+ * burst is granted rather than by the tracking block, which would otherwise
+ * still see burst_active low and miss it.  Getting this wrong leaves the
+ * arbiter latched to one master forever.
+ */
+
+module a2065_ddram_arbiter #(
+    parameter ADDR_W  = 29,
+    parameter DATA_W  = 64,
+    parameter BURST_W = 8,
+    parameter BYTE_W  = 8
+)(
+    input  wire                clk,
+    input  wire                rst,
+
+    // Master 0 — Minimig fast RAM (priority)
+    input  wire [ADDR_W-1:0]   m0_address,
+    input  wire [BURST_W-1:0]  m0_burstcount,
+    input  wire                m0_read,
+    output wire [DATA_W-1:0]   m0_readdata,
+    output wire                m0_readdatavalid,
+    input  wire [DATA_W-1:0]   m0_writedata,
+    input  wire [BYTE_W-1:0]   m0_byteenable,
+    input  wire                m0_write,
+    output wire                m0_waitrequest,
+
+    // Master 1 — A2065 mailbox
+    input  wire [ADDR_W-1:0]   m1_address,
+    input  wire [BURST_W-1:0]  m1_burstcount,
+    input  wire                m1_read,
+    output wire [DATA_W-1:0]   m1_readdata,
+    output wire                m1_readdatavalid,
+    input  wire [DATA_W-1:0]   m1_writedata,
+    input  wire [BYTE_W-1:0]   m1_byteenable,
+    input  wire                m1_write,
+    output wire                m1_waitrequest,
+
+    // Slave — DDR3
+    output wire [ADDR_W-1:0]   s_address,
+    output wire [BURST_W-1:0]  s_burstcount,
+    output wire                s_read,
+    input  wire [DATA_W-1:0]   s_readdata,
+    input  wire                s_readdatavalid,
+    output wire [DATA_W-1:0]   s_writedata,
+    output wire [BYTE_W-1:0]   s_byteenable,
+    output wire                s_write,
+    input  wire                s_waitrequest
+);
+
+    localparam M0 = 1'b0;
+    localparam M1 = 1'b1;
+
+    reg               busy;          // a burst is in flight
+    reg               owner;         // which master owns it
+    reg               owner_is_read;
+    reg [BURST_W:0]   beats_left;
+
+    wire m0_req = m0_read | m0_write;
+    wire m1_req = m1_read | m1_write;
+
+    // While idle, m0 wins outright; m1 is granted only when m0 is quiet.
+    wire       start_m0 = !busy && m0_req;
+    wire       start_m1 = !busy && !m0_req && m1_req;
+    wire       sel      = busy ? owner : (m0_req ? M0 : M1);
+    wire       starting = start_m0 | start_m1;
+
+    wire [BURST_W-1:0] sel_burstcount = (sel == M0) ? m0_burstcount : m1_burstcount;
+    wire               sel_read       = (sel == M0) ? m0_read       : m1_read;
+    wire               sel_write      = (sel == M0) ? m0_write      : m1_write;
+
+    // A beat is accepted whenever the slave takes a write, or a read command is
+    // issued. Read data comes back later and is counted by readdatavalid.
+    wire write_beat = sel_write && !s_waitrequest;
+
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            busy          <= 1'b0;
+            owner         <= M0;
+            owner_is_read <= 1'b0;
+            beats_left    <= 0;
+        end
+        else if (!busy) begin
+            if (starting && !s_waitrequest) begin
+                owner         <= sel;
+                owner_is_read <= sel_read;
+                if (sel_read) begin
+                    // The whole read burst is issued as one command; every
+                    // beat is still outstanding until its data comes back.
+                    busy       <= 1'b1;
+                    beats_left <= sel_burstcount;
+                end
+                else begin
+                    // The first write beat is placed in this same cycle, so
+                    // only the remainder is outstanding.
+                    busy       <= (sel_burstcount > 1);
+                    beats_left <= sel_burstcount - 1'b1;
+                end
+            end
+        end
+        else if (owner_is_read ? s_readdatavalid : write_beat) begin
+            beats_left <= beats_left - 1'b1;
+            if (beats_left == 1) busy <= 1'b0;
+        end
+    end
+
+    // Read data returns out of band. Only one read burst is ever in flight
+    // (a new burst cannot start while busy), so remembering the owner of the
+    // most recent one is enough to route it.
+    reg rd_owner;
+    always @(posedge clk or posedge rst) begin
+        if (rst) rd_owner <= M0;
+        else if (!busy && starting && !s_waitrequest && sel_read) rd_owner <= sel;
+    end
+
+    assign s_address    = (sel == M0) ? m0_address    : m1_address;
+    assign s_burstcount = (sel == M0) ? m0_burstcount : m1_burstcount;
+    assign s_read       = (sel == M0) ? m0_read       : m1_read;
+    assign s_writedata  = (sel == M0) ? m0_writedata  : m1_writedata;
+    assign s_byteenable = (sel == M0) ? m0_byteenable : m1_byteenable;
+    assign s_write      = (sel == M0) ? m0_write      : m1_write;
+
+    // Back-pressure. A master that is merely idle must see the slave's own
+    // waitrequest, not a busy signal: ddram_ctrl only issues a request while
+    // ~DDRAM_BUSY, so holding an idle master off would stop it ever asking,
+    // which in turn would keep it held off — a deadlock that never lets the
+    // 68k reach fast RAM. Only a master that genuinely cannot have the bus
+    // right now is stalled.
+    assign m0_waitrequest = (busy && owner == M1) ? 1'b1          // m1 mid-burst
+                                                  : s_waitrequest;
+
+    assign m1_waitrequest = (busy && owner == M1) ? s_waitrequest // m1 owns it
+                          : (busy || m0_req)      ? 1'b1          // m0 owns or wants it
+                                                  : s_waitrequest;
+
+    assign m0_readdata       = s_readdata;
+    assign m1_readdata       = s_readdata;
+    assign m0_readdatavalid  = s_readdatavalid && (rd_owner == M0);
+    assign m1_readdatavalid  = s_readdatavalid && (rd_owner == M1);
+
+endmodule

--- a/rtl/A2065/a2065_regfile.v
+++ b/rtl/A2065/a2065_regfile.v
@@ -1,0 +1,130 @@
+/*
+ * a2065_regfile.v
+ *
+ * Am7990 LANCE register file + CSR doorbell.
+ *
+ * Replaces the DTACK-stretch bridge RPC (a2065_registers.v bridge mode).
+ * The 68k reads/writes RAP/RDP at full bus speed.  RDP writes raise a
+ * doorbell for the ARM daemon; the ARM writes status bits back into the
+ * CSR shadow which the 68k polls at full speed.
+ *
+ * No DTACK stretch on any access.  RDP writes always complete immediately;
+ * if the previous doorbell is still pending, the new write overwrites it
+ * (the ARM daemon only needs the latest register state).
+ */
+
+module a2065_regfile (
+    input  wire        clk,
+    input  wire        rst_n,
+
+    input  wire [23:0] cpu_addr,
+    input  wire        cpu_rw,
+    input  wire        cpu_as_n,
+    input  wire        cpu_ds_n,
+    input  wire [15:0] cpu_data_in,
+    output wire [15:0] cpu_data_out,
+    output wire        regs_nrdy,
+
+    input  wire [7:0]  card_base,
+    input  wire        card_configured,
+
+    output reg         cmd_pending,
+    output reg  [6:0]  cmd_rap,
+    output reg  [15:0] cmd_data,
+    input  wire        cmd_clear,
+
+    input  wire [15:0] csr0_in,
+    input  wire [15:0] csr1_in,
+    input  wire [15:0] csr2_in,
+    input  wire [15:0] csr3_in
+);
+
+    wire sel_chipreg = card_configured &&
+                       (cpu_addr[23:16] == card_base) &&
+                       (cpu_addr[15:2]  == 14'h1000) &&
+                       (!cpu_as_n) &&
+                       (!cpu_ds_n);
+
+    wire is_rap = cpu_addr[1];
+
+    reg [6:0]  rap;
+    reg [15:0] csr_shadow [0:3];
+
+    always @(posedge clk) begin
+        csr_shadow[0] <= csr0_in;
+        csr_shadow[1] <= csr1_in;
+        csr_shadow[2] <= csr2_in;
+        csr_shadow[3] <= csr3_in;
+    end
+
+    reg [15:0] chip_id_out;
+    always @(*) begin
+        chip_id_out = 16'h0000;
+        case (rap)
+        7'd88: chip_id_out = 16'h0001;
+        7'd89: chip_id_out = 16'h3003;
+        default: begin
+            if (rap < 4)
+                chip_id_out = csr_shadow[rap];
+        end
+        endcase
+    end
+
+    assign cpu_data_out = (sel_chipreg && cpu_rw) ?
+                          (is_rap ? {9'b0, rap} : chip_id_out) : 16'h0000;
+
+    reg cmd_clear_s, cmd_clear_s1;
+    always @(posedge clk) begin
+        cmd_clear_s  <= cmd_clear;
+        cmd_clear_s1 <= cmd_clear_s;
+    end
+
+    // RDP writes back-pressure (stretch DTACK) until the doorbell is fully
+    // drained by the ARM daemon (cmd_clear arrives only after the mailbox
+    // sees the daemon clear the DDR3 CMD slot).  This serializes the rapid
+    // RAP/RDP register sequence used by LANCE INIT so no write is lost.
+    // RAP writes stay local and immediate; reads are unaffected (zero latency).
+    localparam W_IDLE = 2'd0, W_WAIT = 2'd1, W_DONE = 2'd2;
+    reg [1:0] wstate;
+
+    wire rdp_wr = sel_chipreg && !cpu_rw && !is_rap;
+    wire rap_wr = sel_chipreg && !cpu_rw &&  is_rap;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            rap         <= 7'd0;
+            cmd_pending <= 1'b0;
+            cmd_rap     <= 7'd0;
+            cmd_data    <= 16'd0;
+            wstate      <= W_IDLE;
+        end else begin
+            if (rap_wr)
+                rap <= cpu_data_in[6:0];
+
+            case (wstate)
+            W_IDLE: begin
+                if (rdp_wr) begin
+                    cmd_rap     <= rap;
+                    cmd_data    <= cpu_data_in;
+                    cmd_pending <= 1'b1;
+                    wstate      <= W_WAIT;
+                end
+            end
+            W_WAIT: begin
+                if (cmd_clear_s1) begin
+                    cmd_pending <= 1'b0;
+                    wstate      <= W_DONE;
+                end
+            end
+            W_DONE: begin
+                if (!rdp_wr)            // bus cycle ended (DS deasserted)
+                    wstate <= W_IDLE;
+            end
+            default: wstate <= W_IDLE;
+            endcase
+        end
+    end
+
+    assign regs_nrdy = (wstate == W_WAIT);
+
+endmodule

--- a/rtl/A2065/sim/tb_boardram_cdc.v
+++ b/rtl/A2065/sim/tb_boardram_cdc.v
@@ -1,0 +1,135 @@
+/*
+ * tb_boardram_cdc.v — 68k boardram access across the clk_sys/DDRAM_CLK boundary.
+ *
+ * a2065_ddram runs in the Amiga's clock domain and stretches DTACK until the
+ * mailbox, in the DDR3 clock domain, has completed the transfer. The two are
+ * roughly 28 MHz and 114 MHz, so any reply the mailbox sends as a single-cycle
+ * pulse (~9 ns) is far shorter than the ~35 ns sampling period on the other
+ * side and can be missed entirely — which strands DTACK asserted and hangs the
+ * 68k on its first boardram access.
+ *
+ * This drives real 68k-style bus cycles through both modules against a stub
+ * DDR3 slave and requires each cycle to terminate, so a reply that cannot cross
+ * the domain shows up as a failed test rather than a hung Amiga.
+ */
+`timescale 1ns/1ps
+
+module tb_boardram_cdc;
+
+    // 28.636 MHz Amiga side, 114.545 MHz DDR3 side — the real ratio.
+    reg clk_sys = 0;  always #17.46 clk_sys = ~clk_sys;
+    reg clk_ddr = 0;  always #4.364 clk_ddr = ~clk_ddr;
+
+    reg rst_n = 0;
+
+    reg  [23:1] cpu_addr = 0;
+    reg  [15:0] cpu_data_in = 0;
+    reg         cpu_rw = 1, cpu_as_n = 1, cpu_uds_n = 1, cpu_lds_n = 1, sel = 0;
+    wire [15:0] cpu_data_out;
+    wire        nrdy;
+
+    wire        req_valid, req_rw, req_ack, resp_valid;
+    wire [13:0] req_addr;
+    wire [15:0] req_wdata, resp_data;
+    wire [1:0]  req_be;
+
+    integer pass = 0, fail = 0;
+    task check(input cond, input [511:0] name);
+        begin
+            if (cond) begin pass = pass + 1; $display("  PASS  %0s", name); end
+            else      begin fail = fail + 1; $display("  FAIL  %0s", name); end
+        end
+    endtask
+
+    a2065_ddram ddram (
+        .clk_sys(clk_sys), .rst_n_sys(rst_n),
+        .cpu_addr(cpu_addr), .cpu_data_in(cpu_data_in), .cpu_data_out(cpu_data_out),
+        .cpu_rw(cpu_rw), .cpu_as_n(cpu_as_n), .cpu_uds_n(cpu_uds_n), .cpu_lds_n(cpu_lds_n),
+        .sel(sel), .nrdy(nrdy),
+        .bram_req_valid(req_valid), .bram_req_addr(req_addr),
+        .bram_req_wdata(req_wdata), .bram_req_rw(req_rw), .bram_req_be(req_be),
+        .bram_req_ack_audio(req_ack),
+        .bram_resp_valid_audio(resp_valid), .bram_resp_data_audio(resp_data)
+    );
+
+    wire [28:0] avl_address;
+    wire [7:0]  avl_burstcount, avl_byteenable;
+    wire        avl_read, avl_write;
+    wire [63:0] avl_writedata;
+    reg  [63:0] avl_readdata = 64'h3333_2222_1111_0000;
+    reg         avl_readdatavalid = 0;
+    wire        avl_waitrequest = 1'b0;      // stub slave, always ready
+
+    a2065_ddr3_mailbox mailbox (
+        .clk(clk_ddr), .rst_n(rst_n),
+        .cmd_pending(1'b0), .cmd_rap(7'd0), .cmd_data(16'd0), .cmd_clear(),
+        .csr0_out(), .csr1_out(), .csr2_out(), .csr3_out(), .a2065_int2(),
+        .bram_req_valid(req_valid), .bram_req_addr(req_addr),
+        .bram_req_wdata(req_wdata), .bram_req_rw(req_rw), .bram_req_be(req_be),
+        .bram_req_ack(req_ack),
+        .bram_resp_valid(resp_valid), .bram_resp_data(resp_data),
+        .avl_address(avl_address), .avl_burstcount(avl_burstcount),
+        .avl_read(avl_read), .avl_readdata(avl_readdata),
+        .avl_readdatavalid(avl_readdatavalid),
+        .avl_writedata(avl_writedata), .avl_byteenable(avl_byteenable),
+        .avl_write(avl_write), .avl_waitrequest(avl_waitrequest)
+    );
+
+    // Stub DDR3: return data one cycle after any read is accepted.
+    always @(posedge clk_ddr) avl_readdatavalid <= avl_read;
+
+    // One 68k bus cycle, with a bound on how long DTACK may be stretched.
+    // Returns done=0 if the cycle never terminated (the hang being guarded).
+    task bus_cycle(input rw, input [23:1] addr, input [15:0] wdata, output done);
+        integer guard;
+        begin
+            done = 0; guard = 0;
+            @(negedge clk_sys);
+            cpu_addr = addr; cpu_data_in = wdata; cpu_rw = rw; sel = 1;
+            @(negedge clk_sys);
+            cpu_as_n = 0; cpu_uds_n = 0; cpu_lds_n = 0;   // strobes assert
+            while (guard < 400) begin
+                @(negedge clk_sys);
+                if (!nrdy) begin done = 1; guard = 400; end
+                else guard = guard + 1;
+            end
+            cpu_as_n = 1; cpu_uds_n = 1; cpu_lds_n = 1; sel = 0;   // cycle ends
+            repeat (4) @(negedge clk_sys);
+        end
+    endtask
+
+    reg done;
+    integer i;
+
+    initial begin
+        $display("\n=== tb_boardram_cdc ===");
+        repeat (8) @(negedge clk_sys);
+        rst_n = 1;
+        repeat (4) @(negedge clk_sys);
+
+        // A single write is what the buffer memory test does first.
+        bus_cycle(1'b0, 23'h548000 >> 1, 16'hA5A5, done);
+        check(done, "boardram write completes (DTACK released)");
+
+        bus_cycle(1'b1, 23'h548000 >> 1, 16'h0000, done);
+        check(done, "boardram read completes (DTACK released)");
+
+        // The buffer test walks the whole window, so back-to-back cycles must
+        // keep completing — a handshake that only works once still hangs.
+        done = 1;
+        for (i = 0; i < 8 && done; i = i + 1)
+            bus_cycle(i[0], 23'h548000 >> 1, 16'h1234, done);
+        check(done, "8 back-to-back boardram cycles all complete");
+
+        $display("=== %0d passed, %0d failed ===\n", pass, fail);
+        if (fail) $fatal(1, "boardram CDC tests failed");
+        $finish;
+    end
+
+    initial begin
+        #500000;
+        $display("GLOBAL TIMEOUT — boardram handshake wedged");
+        $fatal(1, "timeout");
+    end
+
+endmodule

--- a/rtl/A2065/sim/tb_cmd_ring.v
+++ b/rtl/A2065/sim/tb_cmd_ring.v
@@ -1,0 +1,150 @@
+/*
+ * tb_cmd_ring.v — 68k register writes must complete without the host.
+ *
+ * The deadlock this guards against: Main is single-threaded, and while it sits
+ * in its IDE handler waiting on the Amiga, the Amiga must not be sitting on a
+ * stretched DTACK waiting on Main. Register writes therefore have to retire on
+ * FPGA progress alone — the entry reaching DDR3 — and never on the host having
+ * read it.
+ *
+ * The host is deliberately absent here: nothing in this bench ever reads the
+ * ring or writes anything back. If a write still needs the host, the bus never
+ * releases and the test fails.
+ */
+`timescale 1ns/1ps
+
+module tb_cmd_ring;
+
+    reg clk_sys = 0; always #17.46 clk_sys = ~clk_sys;   // 28.6 MHz, Amiga side
+    reg clk_ddr = 0; always #4.364 clk_ddr = ~clk_ddr;   // 114.5 MHz, DDR3 side
+    reg rst_n = 0;
+
+    reg  [23:0] cpu_addr = 0;
+    reg         cpu_rw = 1, cpu_as_n = 1, cpu_ds_n = 1;
+    reg  [15:0] cpu_data_in = 0;
+    wire [15:0] cpu_data_out;
+    wire        regs_nrdy;
+
+    wire        cmd_pending, cmd_clear;
+    wire [6:0]  cmd_rap;
+    wire [15:0] cmd_data;
+
+    integer pass = 0, fail = 0;
+    task check(input cond, input [511:0] name);
+        begin
+            if (cond) begin pass = pass + 1; $display("  PASS  %0s", name); end
+            else      begin fail = fail + 1; $display("  FAIL  %0s", name); end
+        end
+    endtask
+
+    a2065_regfile regfile (
+        .clk(clk_sys), .rst_n(rst_n),
+        .cpu_addr(cpu_addr), .cpu_rw(cpu_rw), .cpu_as_n(cpu_as_n),
+        .cpu_ds_n(cpu_ds_n), .cpu_data_in(cpu_data_in),
+        .cpu_data_out(cpu_data_out), .regs_nrdy(regs_nrdy),
+        .card_base(8'hEA), .card_configured(1'b1),
+        .cmd_pending(cmd_pending), .cmd_rap(cmd_rap), .cmd_data(cmd_data),
+        .cmd_clear(cmd_clear),
+        .csr0_in(16'h0004), .csr1_in(16'd0), .csr2_in(16'd0), .csr3_in(16'd0)
+    );
+
+    wire [28:0] avl_address;
+    wire [7:0]  avl_burstcount, avl_byteenable;
+    wire        avl_read, avl_write;
+    wire [63:0] avl_writedata;
+    reg  [63:0] avl_readdata = 0;
+    reg         avl_readdatavalid = 0;
+    wire        avl_waitrequest = 1'b0;
+
+    a2065_ddr3_mailbox mailbox (
+        .clk(clk_ddr), .rst_n(rst_n),
+        .cmd_pending(cmd_pending), .cmd_rap(cmd_rap), .cmd_data(cmd_data),
+        .cmd_clear(cmd_clear),
+        .csr0_out(), .csr1_out(), .csr2_out(), .csr3_out(), .a2065_int2(),
+        .bram_req_valid(1'b0), .bram_req_addr(14'd0), .bram_req_wdata(16'd0),
+        .bram_req_rw(1'b0), .bram_req_be(2'b11),
+        .bram_req_ack(), .bram_resp_valid(), .bram_resp_data(),
+        .avl_address(avl_address), .avl_burstcount(avl_burstcount),
+        .avl_read(avl_read), .avl_readdata(avl_readdata),
+        .avl_readdatavalid(avl_readdatavalid),
+        .avl_writedata(avl_writedata), .avl_byteenable(avl_byteenable),
+        .avl_write(avl_write), .avl_waitrequest(avl_waitrequest)
+    );
+
+    always @(posedge clk_ddr) avl_readdatavalid <= avl_read;
+
+    // Watch what the mailbox posts, so the bench can tell a ring entry from
+    // the index publication that follows it.
+    localparam RING = 29'h03FE0000 + 29'h1100;
+    localparam WPTR = 29'h03FE0000 + 29'h1001;
+    integer ring_writes = 0;
+    reg [63:0] last_entry = 0;
+    reg [31:0] last_wptr = 32'hFFFFFFFF;
+    always @(posedge clk_ddr) begin
+        if (avl_write && !avl_waitrequest) begin
+            if (avl_address >= RING && avl_address < RING + 256) begin
+                ring_writes <= ring_writes + 1;
+                last_entry  <= avl_writedata;
+            end
+            else if (avl_address == WPTR) last_wptr <= avl_writedata[31:0];
+        end
+    end
+
+    // A 68k write to RDP, with a bound on the DTACK stretch.
+    task rdp_write(input [15:0] val, output done);
+        integer guard;
+        begin
+            done = 0; guard = 0;
+            @(negedge clk_sys);
+            cpu_addr = 24'hEA4000; cpu_data_in = val; cpu_rw = 0;
+            @(negedge clk_sys);
+            cpu_as_n = 0; cpu_ds_n = 0;
+            while (guard < 300) begin
+                @(negedge clk_sys);
+                if (!regs_nrdy) begin done = 1; guard = 300; end
+                else guard = guard + 1;
+            end
+            cpu_as_n = 1; cpu_ds_n = 1; cpu_rw = 1;
+            repeat (3) @(negedge clk_sys);
+        end
+    endtask
+
+    reg done;
+    integer i, before;
+
+    initial begin
+        $display("\\n=== tb_cmd_ring (no host present) ===");
+        repeat (10) @(negedge clk_sys);
+        rst_n = 1;
+        repeat (20) @(negedge clk_sys);
+
+        check(last_wptr == 32'd0, "index published at reset");
+
+        before = ring_writes;
+        rdp_write(16'h0004, done);
+        check(done, "register write completes with no host to drain it");
+        check(ring_writes == before + 1, "one ring entry posted");
+        check(last_entry[0] == 1'b1 &&
+              last_entry[23:8] == 16'h0004, "entry carries the written data");
+        check(last_wptr == 32'd1, "write index advanced");
+
+        // The LANCE init sequence is a burst of back-to-back writes; every one
+        // must retire, which a single un-drained slot could not manage.
+        done = 1;
+        for (i = 0; i < 12 && done; i = i + 1)
+            rdp_write(16'h0040 + i[15:0], done);
+        check(done, "12 back-to-back register writes all complete");
+        check(last_wptr == 32'd13, "index advanced once per write");
+
+        $display("=== %0d passed, %0d failed ===\\n", pass, fail);
+        if (fail) $fatal(1, "cmd ring tests failed");
+        $finish;
+    end
+
+    initial begin
+        #400000;
+        $display("GLOBAL TIMEOUT — register write never retired");
+        $fatal(1, "timeout");
+    end
+
+endmodule

--- a/rtl/A2065/sim/tb_ddram_arbiter.v
+++ b/rtl/A2065/sim/tb_ddram_arbiter.v
@@ -1,0 +1,228 @@
+/*
+ * tb_ddram_arbiter.v — checks a2065_ddram_arbiter.
+ *
+ * The failure this guards against: the previous arbiter latched its grant to
+ * one master forever after a single-beat write, which on the core's DDR3 port
+ * would starve the 68k fast-RAM path and hang the Amiga. So the tests care
+ * mostly about the bus being released, and about m0 never being made to wait
+ * behind m1.
+ */
+`timescale 1ns/1ps
+
+module tb_ddram_arbiter;
+
+    reg clk = 0, rst = 1;
+    always #5 clk = ~clk;
+
+    reg  [28:0] m0_address = 0,  m1_address = 0;
+    reg  [7:0]  m0_burstcount = 0, m1_burstcount = 0;
+    reg         m0_read = 0,    m1_read = 0;
+    reg  [63:0] m0_writedata = 0, m1_writedata = 0;
+    reg  [7:0]  m0_byteenable = 8'hFF, m1_byteenable = 8'hFF;
+    reg         m0_write = 0,   m1_write = 0;
+    wire [63:0] m0_readdata, m1_readdata;
+    wire        m0_readdatavalid, m1_readdatavalid;
+    wire        m0_waitrequest, m1_waitrequest;
+
+    wire [28:0] s_address;
+    wire [7:0]  s_burstcount, s_byteenable;
+    wire        s_read, s_write;
+    wire [63:0] s_writedata;
+    reg  [63:0] s_readdata = 0;
+    reg         s_readdatavalid = 0;
+    reg         s_waitrequest = 0;
+
+    integer pass = 0, fail = 0;
+
+    task check(input cond, input [511:0] name);
+        begin
+            if (cond) begin pass = pass + 1; $display("  PASS  %0s", name); end
+            else      begin fail = fail + 1; $display("  FAIL  %0s", name); end
+        end
+    endtask
+
+    a2065_ddram_arbiter dut (
+        .clk(clk), .rst(rst),
+        .m0_address(m0_address), .m0_burstcount(m0_burstcount), .m0_read(m0_read),
+        .m0_readdata(m0_readdata), .m0_readdatavalid(m0_readdatavalid),
+        .m0_writedata(m0_writedata), .m0_byteenable(m0_byteenable),
+        .m0_write(m0_write), .m0_waitrequest(m0_waitrequest),
+        .m1_address(m1_address), .m1_burstcount(m1_burstcount), .m1_read(m1_read),
+        .m1_readdata(m1_readdata), .m1_readdatavalid(m1_readdatavalid),
+        .m1_writedata(m1_writedata), .m1_byteenable(m1_byteenable),
+        .m1_write(m1_write), .m1_waitrequest(m1_waitrequest),
+        .s_address(s_address), .s_burstcount(s_burstcount), .s_read(s_read),
+        .s_readdata(s_readdata), .s_readdatavalid(s_readdatavalid),
+        .s_writedata(s_writedata), .s_byteenable(s_byteenable),
+        .s_write(s_write), .s_waitrequest(s_waitrequest)
+    );
+
+    // Single-beat write from m1, the case that wedged the old arbiter.
+    task m1_single_write(input [28:0] addr);
+        begin
+            @(negedge clk);
+            m1_address = addr; m1_burstcount = 1; m1_writedata = 64'hDEAD; m1_write = 1;
+            @(negedge clk);
+            while (m1_waitrequest) @(negedge clk);
+            m1_write = 0;                       // master drops write once accepted
+        end
+    endtask
+
+    task m0_single_write(input [28:0] addr);
+        begin
+            @(negedge clk);
+            m0_address = addr; m0_burstcount = 1; m0_writedata = 64'hBEEF; m0_write = 1;
+            @(negedge clk);
+            while (m0_waitrequest) @(negedge clk);
+            m0_write = 0;
+        end
+    endtask
+
+    // ddram_ctrl only asserts a request while it sees ~DDRAM_BUSY, so an idle
+    // master that is held off never asks for the bus at all. Model that here:
+    // an arbiter that stalls idle masters deadlocks with this and the 68k never
+    // reaches fast RAM. Times out rather than hanging the run.
+    task m0_gated_write(input [28:0] addr, output ok);
+        integer guard;
+        begin
+            ok = 0;
+            guard = 0;
+            @(negedge clk);
+            while (!ok && guard < 40) begin
+                if (!m0_waitrequest) begin          // only then may it request
+                    m0_address = addr; m0_burstcount = 1;
+                    m0_writedata = 64'hBEEF; m0_write = 1;
+                    @(negedge clk);
+                    if (!m0_waitrequest) begin m0_write = 0; ok = 1; end
+                end
+                else @(negedge clk);
+                guard = guard + 1;
+            end
+            m0_write = 0;
+        end
+    endtask
+
+    integer i;
+    reg ok;
+
+    initial begin
+        $display("\n=== tb_ddram_arbiter ===");
+        repeat (4) @(negedge clk);
+        rst = 0;
+        repeat (2) @(negedge clk);
+
+        // 0. The regression that stopped the Amiga booting: a waitrequest-gated
+        //    master must be able to start from a completely idle bus.
+        m0_gated_write(29'h010, ok);
+        check(ok, "waitrequest-gated m0 can start from idle bus");
+        repeat (2) @(negedge clk);
+        m0_gated_write(29'h018, ok);
+        check(ok, "waitrequest-gated m0 can start again");
+        repeat (2) @(negedge clk);
+
+        // 1. m1 single write, then m0 must still get through. This is the exact
+        //    sequence that left the old arbiter stuck granting m1.
+        m1_single_write(29'h100);
+        repeat (3) @(negedge clk);
+        check(!dut.busy, "bus released after m1 single-beat write");
+
+        fork : m0_after
+            begin
+                m0_single_write(29'h200);
+                disable watchdog0;
+            end
+            begin : watchdog0
+                repeat (20) @(negedge clk);
+                check(1'b0, "m0 write completes after m1 (TIMED OUT)");
+            end
+        join
+        check(1'b1, "m0 write completes after m1 single-beat write");
+
+        // 2. Repeated m1 writes must not accumulate any lockup.
+        for (i = 0; i < 4; i = i + 1) m1_single_write(29'h300 + i);
+        repeat (3) @(negedge clk);
+        check(!dut.busy, "bus released after repeated m1 writes");
+
+        // 3. Priority: with both requesting from idle, m0 must win.
+        @(negedge clk);
+        m0_address = 29'h400; m0_burstcount = 1; m0_write = 1;
+        m1_address = 29'h500; m1_burstcount = 1; m1_write = 1;
+        @(negedge clk);
+        check(s_address == 29'h400 && !m0_waitrequest && m1_waitrequest,
+              "m0 wins arbitration against m1");
+        m0_write = 0;
+        @(negedge clk);
+        while (m1_waitrequest) @(negedge clk);
+        m1_write = 0;
+        repeat (2) @(negedge clk);
+
+        // 4. Burst write from m0 holds the bus for its whole burst.
+        @(negedge clk);
+        m0_address = 29'h600; m0_burstcount = 4; m0_write = 1; m0_writedata = 64'h11;
+        @(negedge clk);                       // beat 1 accepted at grant
+        m1_address = 29'h700; m1_burstcount = 1; m1_write = 1;   // m1 barges in
+        check(m1_waitrequest, "m1 held off during m0 burst");
+        repeat (3) @(negedge clk);            // beats 2..4
+        m0_write = 0;
+        @(negedge clk);
+        check(!m1_waitrequest, "m1 granted once m0 burst completes");
+        while (m1_waitrequest) @(negedge clk);
+        m1_write = 0;
+        repeat (2) @(negedge clk);
+
+        // 5. Read data routes to the master that asked, and only to it.
+        @(negedge clk);
+        m1_address = 29'h800; m1_burstcount = 1; m1_read = 1;
+        @(negedge clk);
+        while (m1_waitrequest) @(negedge clk);
+        m1_read = 0;
+        @(negedge clk);
+        s_readdata = 64'hCAFE; s_readdatavalid = 1;
+        @(negedge clk);
+        check(m1_readdatavalid && !m0_readdatavalid && m1_readdata == 64'hCAFE,
+              "read data routed to m1 only");
+        s_readdatavalid = 0;
+        repeat (2) @(negedge clk);
+        check(!dut.busy, "bus released after m1 read completes");
+
+        // 6. A read must keep the bus until its data returns, not just its
+        //    command being accepted.
+        @(negedge clk);
+        m0_address = 29'h900; m0_burstcount = 2; m0_read = 1;
+        @(negedge clk);
+        while (m0_waitrequest) @(negedge clk);
+        m0_read = 0;
+        @(negedge clk);
+        check(dut.busy, "bus held while read data outstanding");
+        s_readdata = 64'h1; s_readdatavalid = 1; @(negedge clk);
+        s_readdata = 64'h2;                     @(negedge clk);
+        s_readdatavalid = 0;
+        repeat (2) @(negedge clk);
+        check(!dut.busy, "bus released after 2-beat read returns");
+
+        // 7. Slave back-pressure must not corrupt tracking.
+        @(negedge clk);
+        s_waitrequest = 1;
+        m1_address = 29'hA00; m1_burstcount = 1; m1_write = 1;
+        repeat (3) @(negedge clk);
+        check(!dut.busy && m1_waitrequest, "no burst starts while slave stalls");
+        s_waitrequest = 0;
+        @(negedge clk);
+        while (m1_waitrequest) @(negedge clk);
+        m1_write = 0;
+        repeat (2) @(negedge clk);
+        check(!dut.busy, "bus released after stalled write completes");
+
+        $display("=== %0d passed, %0d failed ===\n", pass, fail);
+        if (fail) $fatal(1, "arbiter tests failed");
+        $finish;
+    end
+
+    // Safety net: the whole run should never take this long.
+    initial begin
+        #20000;
+        $display("GLOBAL TIMEOUT — arbiter likely wedged");
+        $fatal(1, "timeout");
+    end
+
+endmodule

--- a/rtl/cpu_wrapper.v
+++ b/rtl/cpu_wrapper.v
@@ -69,6 +69,10 @@ module cpu_wrapper
 	output            toccata_ena,
 	output reg  [7:0] toccata_base,
 
+	output            a2065_ena,
+	output reg  [7:0] a2065_base,
+
+
 	output reg  [1:0] cpustate,
 	output reg  [3:0] cacr,
 	output reg [31:0] nmi_addr
@@ -355,8 +359,10 @@ end
 ///////////////////// AUTOCONFIG ////////////////////////////
 
 reg       ac_toccata;
+reg       ac_a2065;
 reg [2:0] ac_memcard;
 reg [3:0] autocfg_data;
+
 
 always @(*) begin
 	autocfg_data = 4'b1111;
@@ -393,7 +399,40 @@ always @(*) begin
 			6'hb: autocfg_data = 4'b1011;
 			default: ;
 		endcase
-	end 
+	end
+	// A2065 Ethernet (Commodore, mfr=0x0202, product=0x70)
+	else if(ac_a2065) begin
+		case (chip_addr[6:1])
+			6'h0: autocfg_data = 4'b1100; // Zorro-II card, no link, no ROM
+			6'h1: autocfg_data = 4'b0001; // size 64KB
+			// Inverted from here on
+			6'h2: autocfg_data = 4'b1000; // er_Product high nibble
+			6'h3: autocfg_data = 4'b1111; // er_Product low nibble -> 0x70
+			6'h4: autocfg_data = 4'b1111; // er_Flags high
+			6'h5: autocfg_data = 4'b1111; // er_Flags low
+			6'h8: autocfg_data = 4'b1111; // er_Manufacturer high high
+			6'h9: autocfg_data = 4'b1101; // er_Manufacturer high low
+			6'ha: autocfg_data = 4'b1111; // er_Manufacturer low high
+			6'hb: autocfg_data = 4'b1101; // er_Manufacturer low low -> 0x0202
+			// er_SerialNumber bytes 2..5 — the A2065 station address low
+			// bytes, which AmigaOS reads as the card's MAC. Left at zero
+			// (nibbles are inverted, so 4'b1111 reads as 0): the host side
+			// rewrites the source address on the wire, so the card does not
+			// need a unique serial here. Driving these from a register would
+			// mean a real MAC arriving before autoconfig has run.
+			6'hc:  autocfg_data = 4'b1111;
+			6'hd:  autocfg_data = 4'b1111;
+			6'he:  autocfg_data = 4'b1111;
+			6'hf:  autocfg_data = 4'b1111;
+			6'h10: autocfg_data = 4'b1111;
+			6'h11: autocfg_data = 4'b1111;
+			6'h12: autocfg_data = 4'b1111;
+			6'h13: autocfg_data = 4'b1111;
+			6'h14: autocfg_data = 4'b1111; // er_InitDiagVec
+			6'h15: autocfg_data = 4'b1111; // er_InitDiagVec
+			default: ;
+		endcase
+	end
 	// Zorro III RAM 128MB/256MB/384MB
 	else if(ac_memcard[2]) begin
 		case (chip_addr[6:1])
@@ -412,7 +451,7 @@ always @(*) begin
 	end
 end
 
-wire sel_autoconfig = (chip_addr[23:16] == 8'b11101000) && (ac_memcard || ac_toccata); //$E80000 - $E8FFFF
+wire sel_autoconfig = (chip_addr[23:16] == 8'b11101000) && (ac_memcard || ac_toccata || ac_a2065); //$E80000 - $E8FFFF
 
 reg       z2ram_ena;
 reg [4:0] z3ram_base0;
@@ -426,6 +465,7 @@ always @(posedge clk) begin
 	if (~reset | ~reset_out) begin
 		ac_memcard  <= cpucfg[1] ? fastramcfg : fastramcfg[2] ? 3'd3 : {1'b0, fastramcfg[1:0]};
 		ac_toccata  <= 1;
+		ac_a2065    <= 1;
 		z2ram_ena   <= 0;
 		z3ram_ena0  <= 0;
 		z3ram_ena1  <= 0;
@@ -445,6 +485,12 @@ always @(posedge clk) begin
 				ac_toccata<=0;
 			end		
 		end
+		else if(ac_a2065) begin
+			if (chip_addr[6:1] == 6'b100100) begin // Register 0x48 - config, A2065 Ethernet
+				a2065_base <= cpu_dout[7:0];
+				ac_a2065<=0;
+			end
+		end
 		else if(ac_memcard[2]) begin
 			if(chip_addr[6:1] == 6'b100010) begin // Register 0x44, assign base address to ZIII RAM.
 				if(~ac_memcard[1]) begin
@@ -463,5 +509,6 @@ always @(posedge clk) begin
 end
 
 assign toccata_ena = ~ac_toccata;
+assign a2065_ena   = ~ac_a2065;
 
 endmodule

--- a/rtl/ddram_ctrl.v
+++ b/rtl/ddram_ctrl.v
@@ -34,13 +34,26 @@ module ddram_ctrl
 	output            DDRAM_CLK,
 	input             DDRAM_BUSY,
 	output      [7:0] DDRAM_BURSTCNT,
-	output reg [28:0] DDRAM_ADDR,
+	output     [28:0] DDRAM_ADDR,
 	input      [63:0] DDRAM_DOUT,
 	input             DDRAM_DOUT_READY,
-	output reg        DDRAM_RD,
-	output reg [63:0] DDRAM_DIN,
-	output reg  [7:0] DDRAM_BE,
-	output reg        DDRAM_WE,
+	output            DDRAM_RD,
+	output     [63:0] DDRAM_DIN,
+	output      [7:0] DDRAM_BE,
+	output            DDRAM_WE,
+
+	// Second memory port, shared onto the same DDR3 interface. Used by the
+	// A2065 Ethernet card, which touches DDR3 rarely; the CPU's fast RAM has
+	// priority over it and is never made to wait.
+	input      [28:0] mem2_address,
+	input       [7:0] mem2_burstcount,
+	input             mem2_read,
+	output     [63:0] mem2_readdata,
+	output            mem2_readdatavalid,
+	input      [63:0] mem2_writedata,
+	input       [7:0] mem2_byteenable,
+	input             mem2_write,
+	output            mem2_waitrequest,
 
 	// cpu    
 	input      [28:1] cpuAddr,
@@ -126,7 +139,54 @@ end
 assign ramready = cache_hit || write_ena;
 
 assign DDRAM_CLK = sysclk;
-assign DDRAM_BURSTCNT = 1;
+
+// Fast RAM's own view of DDR3. It goes through the arbiter below rather than
+// straight to the pins, so that the second port can share the interface.
+reg  [28:0] ram_addr;
+reg  [63:0] ram_din;
+reg   [7:0] ram_be;
+reg         ram_rd, ram_we;
+wire        ram_busy;
+wire [63:0] ram_dout       = DDRAM_DOUT;
+wire        ram_dout_ready;
+
+a2065_ddram_arbiter arbiter
+(
+	.clk             (sysclk),
+	.rst             (~reset_n),
+
+	.m0_address      (ram_addr),
+	.m0_burstcount   (8'd1),
+	.m0_read         (ram_rd),
+	.m0_readdata     (),
+	.m0_readdatavalid(ram_dout_ready),
+	.m0_writedata    (ram_din),
+	.m0_byteenable   (ram_be),
+	.m0_write        (ram_we),
+	.m0_waitrequest  (ram_busy),
+
+	.m1_address      (mem2_address),
+	.m1_burstcount   (mem2_burstcount),
+	.m1_read         (mem2_read),
+	.m1_readdata     (),
+	.m1_readdatavalid(mem2_readdatavalid),
+	.m1_writedata    (mem2_writedata),
+	.m1_byteenable   (mem2_byteenable),
+	.m1_write        (mem2_write),
+	.m1_waitrequest  (mem2_waitrequest),
+
+	.s_address       (DDRAM_ADDR),
+	.s_burstcount    (DDRAM_BURSTCNT),
+	.s_read          (DDRAM_RD),
+	.s_readdata      (DDRAM_DOUT),
+	.s_readdatavalid (DDRAM_DOUT_READY),
+	.s_writedata     (DDRAM_DIN),
+	.s_byteenable    (DDRAM_BE),
+	.s_write         (DDRAM_WE),
+	.s_waitrequest   (DDRAM_BUSY)
+);
+
+assign mem2_readdata = DDRAM_DOUT;
 
 reg        ddr_swap;
 reg [15:0] ddr_data;
@@ -139,9 +199,9 @@ always @ (posedge sysclk) begin
 	cache_fill <= 0;
 	ddr_data <= dout[{ba, 4'b0000} +:16];
 
-	if(~DDRAM_BUSY) begin
-		DDRAM_WE  <= 0;
-		DDRAM_RD  <= 0;
+	if(~ram_busy) begin
+		ram_we  <= 0;
+		ram_rd  <= 0;
 	end
 
 	if(~reset_n) begin
@@ -150,26 +210,26 @@ always @ (posedge sysclk) begin
 	end
 	else begin
 		case(state)
-			0: if(~DDRAM_BUSY) begin
+			0: if(~ram_busy) begin
 					if(~write_ack & write_req) begin
-						DDRAM_ADDR <= {3'b001, writeAddr[28:3]};
-						DDRAM_BE   <= {6'b000000,writeBE}<<{writeAddr[2:1],1'b0};
-						DDRAM_DIN  <= {writeDat,writeDat,writeDat,writeDat};
-						DDRAM_WE   <= 1;
+						ram_addr <= {3'b001, writeAddr[28:3]};
+						ram_be   <= {6'b000000,writeBE}<<{writeAddr[2:1],1'b0};
+						ram_din  <= {writeDat,writeDat,writeDat,writeDat};
+						ram_we   <= 1;
 						write_ack  <= 1;
 					end
 					else if(cache_req) begin
-						DDRAM_ADDR <= {3'b001, cpuAddr[28:3]};
-						DDRAM_BE   <= 8'hFF;
-						DDRAM_RD   <= 1;
+						ram_addr <= {3'b001, cpuAddr[28:3]};
+						ram_be   <= 8'hFF;
+						ram_rd   <= 1;
 						ba         <= cpuAddr[2:1];
 						state      <= 1;
 						ddr_swap   <= ramshared;
 					end
 				end
-			1: if(~DDRAM_BUSY & DDRAM_DOUT_READY) begin
-					ddr_data      <= DDRAM_DOUT[{ba, 4'b0000} +:16];
-					dout          <= DDRAM_DOUT;
+			1: if(~ram_busy & ram_dout_ready) begin
+					ddr_data      <= ram_dout[{ba, 4'b0000} +:16];
+					dout          <= ram_dout;
 					cache_fill    <= 1;
 					ba            <= ba + 1'd1;
 					state         <= state + 1'd1;

--- a/rtl/gary.v
+++ b/rtl/gary.v
@@ -76,6 +76,8 @@ module gary
 	input         ecs, // ECS chipset enable
 	input         hdc_ena, //enables hdd interface
 
+	input         a2065_ena,
+	input   [7:0] a2065_base,
 	input         toccata_ena,
 	input   [7:0] toccata_base,
 
@@ -96,7 +98,8 @@ module gary
 	output       sel_rtc, //select $DCxxxx
 	output       sel_ide, //select $DAxxxx
 	output       sel_gayle, //select $DExxxx
-	output       sel_toccata, //select $E9xxxx (or whatever's specified by toccata_base)
+	output       sel_toccata,
+	output       sel_a2065,
 	output reg   rom_readonly = 0 //when zero allows to write to $fc-$ff, blocks effect of kick256kmirror.  
 );
 
@@ -178,6 +181,7 @@ assign sel_rtg   = cpu_address_in[23:16]==8'hB8; // $B8xxxxx
 assign sel_bank_1 = cpu_address_in[23:21]==3'b001;
 
 assign sel_toccata = toccata_ena && cpu_address_in[23:16]==toccata_base; // Nominally $e9xxxx
+assign sel_a2065   = a2065_ena && cpu_address_in[23:16]==a2065_base;
 
 //data bus slow down
 assign dbs = cpu_address_in[23:21]==3'b000 || cpu_address_in[23:20]==4'b1100 || cpu_address_in[23:19]==5'b1101_0 || cpu_address_in[23:16]==8'b1101_1111;

--- a/rtl/minimig.v
+++ b/rtl/minimig.v
@@ -248,6 +248,10 @@ module minimig
 	output [15:0] toccata_aud_left,
 	output [15:0] toccata_aud_right,
 
+	// A2065 Ethernet
+	input         a2065_ena,
+	input   [7:0] a2065_base,
+
 	//user i/o
 	output  [1:0] cpucfg,
 	output  [2:0] cachecfg,
@@ -262,7 +266,20 @@ module minimig
 	input         ide_write,
 	input  [15:0] ide_writedata,
 	input         ide_read,
-	output [15:0] ide_readdata
+	output [15:0] ide_readdata,
+
+	// A2065 register file + doorbell
+	// A2065 memory port — goes to ddram_ctrl alongside the fast RAM
+	input         a2065_clk_ddr,
+	output [28:0] a2065_mem_address,
+	output [7:0]  a2065_mem_burstcount,
+	output        a2065_mem_read,
+	input  [63:0] a2065_mem_readdata,
+	input         a2065_mem_readdatavalid,
+	output [63:0] a2065_mem_writedata,
+	output [7:0]  a2065_mem_byteenable,
+	output        a2065_mem_write,
+	input         a2065_mem_waitrequest
 );
 
 
@@ -316,11 +333,13 @@ wire        sel_reg;				//chip register select
 wire        sel_rtc;
 wire        sel_cia_a;			//cia A select
 wire        sel_cia_b;			//cia B select
-wire        sel_toccata;
+	wire        sel_toccata;
+	wire        sel_a2065;
 wire        int2;					//intterrupt 2
 wire        int3;					//intterrupt 3 
 wire        int6;					//intterrupt 6
 wire        int6_toccata;
+wire        a2065_int2_sync;
 wire        freeze;				//Action Replay freeze button
 wire        _fire0;				//joystick 1 fire signal to cia A
 wire        _fire1;				//joystick 2 fire signal to cia A
@@ -488,7 +507,7 @@ paula PAULA1
 	.sof(sof),
 	.strhor(strhor_paula),
 	.vblint(vbl_int),
-	.int2(int2|(ide_fast ? ide_ext_irq : gayle_irq)),
+	.int2(int2|(ide_fast ? ide_ext_irq : gayle_irq)|a2065_int2_sync),
 	.int3(int3),
 	.int6(int6 | int6_toccata),
 	._ipl(_iplx),
@@ -663,7 +682,7 @@ minimig_m68k_bridge CPU1
 	.dbr(dbr),
 	.dbs(dbs),
 	.xbs(xbs),
-	.nrdy(gayle_nrdy & rd_cyc),
+	.nrdy((gayle_nrdy & rd_cyc) | a2065_nrdy),
 	.bls(bls),
 	.memory_config(memory_config[3:0]),
 	._as(_cpu_as),
@@ -784,6 +803,8 @@ gary GARY1
 	.hdc_ena(ide_ena & ~ide_fast), // Gayle decoding enable	
 	.toccata_ena(toccata_ena),
 	.toccata_base(toccata_base),
+	.a2065_ena(a2065_ena),
+	.a2065_base(a2065_base),
 	.ram_rd(ram_rd),
 	.ram_hwr(ram_hwr),
 	.ram_lwr(ram_lwr),
@@ -802,6 +823,7 @@ gary GARY1
 	.sel_gayle(sel_gayle),
 	.sel_rtc(sel_rtc),
 	.sel_toccata(sel_toccata),
+	.sel_a2065(sel_a2065),
 	.reset(reset),
 	.clk(clk),
 	.rom_readonly(rom_readonly),
@@ -892,6 +914,43 @@ toccata #(
 );
 
 //-------------------------------------------------------------------------------------
+// A2065 Ethernet card. Everything the card needs is inside this module; the
+// core sees only the 68k bus, an interrupt, and one memory port.
+
+wire [15:0] a2065_dout;
+wire        a2065_nrdy;
+
+a2065 a2065_inst (
+	.clk_sys          (clk),
+	.rst_n_sys        (~reset),
+
+	.cpu_addr         (cpu_address_out[23:1]),
+	.cpu_data_in      (cpu_data_out),
+	.cpu_data_out     (a2065_dout),
+	.cpu_rw           (cpu_r_w),
+	.cpu_as_n         (_cpu_as),
+	.cpu_uds_n        (_cpu_uds),
+	.cpu_lds_n        (_cpu_lds),
+	.sel              (sel_a2065),
+	.nrdy             (a2065_nrdy),
+	.int2             (a2065_int2_sync),
+
+	.card_base        (a2065_base),
+	.card_configured  (a2065_ena),
+
+	.clk_ddr          (a2065_clk_ddr),
+	.mem_address      (a2065_mem_address),
+	.mem_burstcount   (a2065_mem_burstcount),
+	.mem_read         (a2065_mem_read),
+	.mem_readdata     (a2065_mem_readdata),
+	.mem_readdatavalid(a2065_mem_readdatavalid),
+	.mem_writedata    (a2065_mem_writedata),
+	.mem_byteenable   (a2065_mem_byteenable),
+	.mem_write        (a2065_mem_write),
+	.mem_waitrequest  (a2065_mem_waitrequest)
+);
+
+//-------------------------------------------------------------------------------------
 
 //data multiplexer
 assign cpu_data_in[15:0]= gary_data_out[15:0]
@@ -899,7 +958,8 @@ assign cpu_data_in[15:0]= gary_data_out[15:0]
 							 | gayle_data_out[15:0]
 							 | cart_data_out[15:0]
 							 | rtc_out
-							 | toccata_out;
+							 | toccata_out
+							 | a2065_dout;
 
 assign custom_data_out[15:0] = agnus_data_out[15:0]
 							 | paula_data_out[15:0]


### PR DESCRIPTION
# Add A2065 ZorroII Ethernet card emulation (LANCE Am7990)

## Summary

This PR adds a full hardware emulation of the Commodore **A2065** ZorroII
Ethernet card to the Minimig core. It works with the standard AmigaOS A2065
drivers — no custom Amiga-side software is needed.

The design is split between FPGA fabric and host-side support code:

- **FPGA fabric** (`rtl/A2065/`, this PR): ZorroII autoconfig, a flat DDR3
  boardram window, a zero-latency CSR register file, and INT2 generation into
  Paula.
- **HPS side** (**not in this PR**): the Am7990 LANCE controller state machine,
  TX/RX descriptor ring walker, and raw `AF_PACKET`/`tap` socket. That lives in
  Main_MiSTer under `support/minimig/` — MiSTer-devel/Main_MiSTer#1247.

## `sys/` is untouched

Everything lives in core files. The card shares the DDR3 port the framework
already gives the core through `emu` (`DDRAM_*`) with the Minimig fast-RAM
controller, so no framework file is modified.

Fast RAM has strict priority on that port: it carries every 68k access to Zorro
RAM, whereas the mailbox polls a handful of words and can wait. The two regions
do not overlap — fast RAM sits at `0x20000000` and up, the A2065 window just
below it.

## Nothing makes the Amiga wait on host software

Register writes are posted into a 256-entry ring in DDR3, and the bus is
released as soon as the entry lands. The Amiga therefore never depends on when
the host next runs — which matters because Main is single-threaded and
busy-waits on the Amiga inside its IDE handler; anything that made the Amiga
wait back would deadlock the pair.

## What's in this PR

**New RTL** (`rtl/A2065/`)
- `a2065_regfile.v` — CSR register file + doorbell
- `a2065_ddram.v` — 68k DDR3 boardram window
- `a2065_ddr3_mailbox.v` — mailbox FSM, CMD ring
- `a2065_ddram_arbiter.v` — fixed-priority DDR3 arbiter

**Core changes**
- `rtl/cpu_wrapper.v` — autoconfig nibbles, base latch, enable
- `rtl/gary.v` — `sel_a2065` decode
- `rtl/minimig.v` — instantiation, arbiter, INT2 CDC
- `Minimig.sv`, `Minimig.sdc`, `files.qip`

**Simulation** (`rtl/A2065/sim/`) — the arbiter, the boardram clock crossing at
the real 28/114 MHz ratio, and register writes completing with no host present
at all.

13 files, +1710/−46.

## Verification

On hardware (DE10-Nano):

- **lance-test diagnostics 5/5** — "Controller PASSED diagnostics."
- DHCP, ping (0% loss) and a byte-exact 100 MB download over all four host
  delivery modes, at 479–571 KB/s. The ceiling there is the 68000 itself, not
  the card.

## Notes for reviewers

- Verified on TG68 (68020); fx68k (68000) not exercised.
- Inert without the Main_MiSTer side: the FPGA presents the card via
  autoconfig, but nothing drives the LANCE until that code runs.
