### PR TITLE
minimig: move the CD32/CDTV host transports onto the ext bus

### DIFF
--- a/Minimig.sv
+++ b/Minimig.sv
@@ -69,7 +69,7 @@ wire [21:0] gamma_bus;
 
 wire  [7:0] uart_mode;
 
-hps_io #(.CONF_STR(CONF_STR), .CONF_STR_BRAM(0), .VDNUM(2), .BLKSZ(3)) hps_io
+hps_io #(.CONF_STR(CONF_STR), .CONF_STR_BRAM(0)) hps_io
 (
 	.clk_sys(clk_sys),
 	.HPS_BUS({HPS_BUS[45:42],ce_pix,HPS_BUS[40:0]}),
@@ -87,20 +87,6 @@ hps_io #(.CONF_STR(CONF_STR), .CONF_STR_BRAM(0), .VDNUM(2), .BLKSZ(3)) hps_io
 	.joystick_l_analog_1(JOYA1),
 
 	.ioctl_wait(io_wait),
-
-	.img_mounted(img_mounted),
-	.img_readonly(img_readonly),
-	.img_size(img_size),
-
-	.sd_lba(sd_lba),
-	.sd_blk_cnt(sd_blk_cnt),
-	.sd_rd(sd_rd),
-	.sd_wr(sd_wr),
-	.sd_ack(sd_ack),
-	.sd_buff_addr(sd_buff_addr),
-	.sd_buff_dout(sd_buff_dout),
-	.sd_buff_din(sd_buff_din),
-	.sd_buff_wr(sd_buff_wr),
 
 	.buttons(buttons),
 	.forced_scandoubler(forced_scandoubler),
@@ -146,51 +132,6 @@ wire        cdtv_stch_ack_clr;
 wire        cdtv_sec_byte_push_w;
 wire  [7:0] cdtv_sec_byte_data_w;
 wire        cdtv_req;
-
-//
-wire        img_mounted;
-wire        img_readonly;
-wire [63:0] img_size;
-wire [31:0] sd_lba   [1:0];
-wire  [5:0] sd_blk_cnt[1:0];
-wire  [1:0] sd_ack;
-wire [13:0] sd_buff_addr;
-wire  [7:0] sd_buff_dout;
-wire  [7:0] sd_buff_din[1:0];
-wire        sd_buff_wr;
-
-reg         sd_rd_nvr;
-reg         sd_wr_nvr;
-reg         img_mounted_d;
-
-wire  [1:0] sd_rd = {1'b0, sd_rd_nvr};
-wire  [1:0] sd_wr = {1'b0, sd_wr_nvr};
-assign sd_lba[0]      = 32'd0;
-assign sd_lba[1]      = 32'd0;
-assign sd_blk_cnt[0]  = 6'd0;
-assign sd_blk_cnt[1]  = 6'd0;
-assign sd_buff_din[0] = 8'h00;
-assign sd_buff_din[1] = 8'h00;
-
-always @(posedge clk_sys) begin
-	img_mounted_d <= img_mounted;
-	if (img_mounted && !img_mounted_d &&
-	    (img_size == 64'd1024) && !img_readonly) begin
-		sd_rd_nvr <= 1'b1;
-	end else if (sd_ack[0]) begin
-		sd_rd_nvr <= 1'b0;
-	end
-	sd_wr_nvr <= 1'b0;
-end
-
-wire [9:0]  nvr_load_addr  = sd_buff_addr[9:0];
-wire [7:0]  nvr_load_din   = sd_buff_dout;
-wire        nvr_load_we    = sd_buff_wr & sd_ack[0];
-
-wire        akiko_sec_dma_active = sd_ack[1];
-wire  [7:0] akiko_sec_dma_byte   = sd_buff_dout;
-wire [13:0] akiko_sec_dma_addr   = sd_buff_addr;
-wire        akiko_sec_dma_we     = sd_buff_wr;
 
 wire        akiko_dma_req_w;
 wire        akiko_dma_we_w;
@@ -762,16 +703,7 @@ fastchip fastchip
 	.akiko_uio_req       (akiko_req       ),
 	.akiko_uio_sec_req   (akiko_sec_req   ),
 	.akiko_uio_rx_busy   (akiko_rx_busy   ),
-	.akiko_uio_nvr_dirty (akiko_nvr_dirty ),
-
-	.nvr_load_addr (nvr_load_addr),
-	.nvr_load_din  (nvr_load_din ),
-	.nvr_load_we   (nvr_load_we  ),
-
-	.hps_sec_dma_active (akiko_sec_dma_active),
-	.hps_sec_dma_byte   (akiko_sec_dma_byte  ),
-	.hps_sec_dma_addr   (akiko_sec_dma_addr  ),
-	.hps_sec_dma_we     (akiko_sec_dma_we    )
+	.akiko_uio_nvr_dirty (akiko_nvr_dirty )
 );
 
 

--- a/rtl/akiko.v
+++ b/rtl/akiko.v
@@ -72,11 +72,6 @@ module akiko #(parameter NATIVE_CD32 = 0)
 	input       [7:0] nvr_load_din,
 	input             nvr_load_we,
 
-	input             hps_sec_dma_active,
-	input       [7:0] hps_sec_dma_byte,
-	input      [13:0] hps_sec_dma_addr,
-	input             hps_sec_dma_we,
-
 	input             hps_subcode_push,
 	input       [7:0] hps_subcode_byte,
 	input             hps_subcode_done
@@ -196,13 +191,9 @@ if (NATIVE_CD32) begin : g_cd
 	reg [11:0] sec_wr_ptr;
 	reg        sector_ready;
 
-	wire        sec_w_we   = hps_sec_dma_active
-	                          ? (hps_sec_dma_we && hps_sec_dma_addr < 14'd2352)
-	                          : (hps_sec_push  && sec_wr_ptr != 12'd2352);
-	wire [11:0] sec_w_addr = hps_sec_dma_active
-	                          ? hps_sec_dma_addr[11:0] : sec_wr_ptr;
-	wire  [7:0] sec_w_din  = hps_sec_dma_active
-	                          ? hps_sec_dma_byte : hps_sec_byte;
+	wire        sec_w_we   = hps_sec_push && sec_wr_ptr != 12'd2352;
+	wire [11:0] sec_w_addr = sec_wr_ptr;
+	wire  [7:0] sec_w_din  = hps_sec_byte;
 	reg  [7:0] cdrom_sector_counter;
 	reg        pbx_busy;
 	reg  [1:0] pbx_state;
@@ -587,18 +578,13 @@ if (NATIVE_CD32) begin : g_cd
 				sector_buffer[sec_w_addr] <= sec_w_din;
 			end
 
-			if (hps_sec_dma_active) begin
-				if (hps_sec_dma_we && hps_sec_dma_addr == 14'd2351
-				    && !sector_ready && !enable_rising) sector_ready <= 1'b1;
-			end else begin
-				if (hps_sec_push && !sector_ready && sec_wr_ptr != 12'd2352
-				    && !enable_rising) begin
-					sec_wr_ptr <= sec_wr_ptr + 12'd1;
-				end
-				if (hps_sec_done) begin
-					if (sec_wr_ptr == 12'd2352 && !enable_rising) sector_ready <= 1'b1;
-					sec_wr_ptr <= 12'h0;
-				end
+			if (hps_sec_push && !sector_ready && sec_wr_ptr != 12'd2352
+			    && !enable_rising) begin
+				sec_wr_ptr <= sec_wr_ptr + 12'd1;
+			end
+			if (hps_sec_done) begin
+				if (sec_wr_ptr == 12'd2352 && !enable_rising) sector_ready <= 1'b1;
+				sec_wr_ptr <= 12'h0;
 			end
 
 			if (hps_subcode_push && !subcode_ready && !subcode_busy

--- a/rtl/akiko_hps_bridge.v
+++ b/rtl/akiko_hps_bridge.v
@@ -23,7 +23,7 @@ module akiko_hps_bridge
 	input             uio_cs_subcode,
 	input             uio_wr,
 	input             uio_rd,
-	input       [7:0] uio_din,
+	input      [15:0] uio_din,
 	output      [7:0] uio_dout,
 
 	input             cmd_pending,
@@ -46,6 +46,8 @@ module akiko_hps_bridge
 
 	output      [9:0] nvr_addr,
 	input       [7:0] nvr_dout,
+	output      [7:0] nvr_load_din,
+	output            nvr_load_we,
 	output            nvr_clear_dirty,
 	output            nvr_done,
 	input             nvr_dirty,
@@ -67,7 +69,13 @@ reg saw_write;
 
 reg [9:0] nvr_addr_cnt;
 
+reg hi_sec;
+reg hi_nvr;
+
 wire cs_cmd = uio_cs & ~uio_cs_sec & ~uio_cs_nvr & ~uio_cs_subcode;
+
+wire wr_sec = uio_wr & uio_cs & uio_cs_sec;
+wire wr_nvr = uio_wr & uio_cs & uio_cs_nvr;
 
 always @(posedge clk) begin
 	if (reset) begin
@@ -78,7 +86,11 @@ always @(posedge clk) begin
 		saw_read     <= 1'b0;
 		saw_write    <= 1'b0;
 		nvr_addr_cnt <= 10'd0;
+		hi_sec       <= 1'b0;
+		hi_nvr       <= 1'b0;
 	end else begin
+		hi_sec <= wr_sec;
+		hi_nvr <= wr_nvr;
 		cs_d         <= uio_cs;
 		cs_sec_d     <= uio_cs_sec;
 		cs_nvr_d     <= uio_cs_nvr;
@@ -92,7 +104,7 @@ always @(posedge clk) begin
 		end
 		if (uio_cs_nvr & ~cs_nvr_d) begin
 			nvr_addr_cnt <= 10'd0;
-		end else if (uio_rd & uio_cs_nvr) begin
+		end else if ((uio_rd & uio_cs_nvr) | wr_nvr | hi_nvr) begin
 			nvr_addr_cnt <= nvr_addr_cnt + 10'd1;
 		end
 	end
@@ -102,16 +114,18 @@ wire xfer_end = cs_d & ~uio_cs;
 
 assign cmd_pop         = uio_rd & cs_cmd;
 assign result_push     = uio_wr & cs_cmd;
-assign result_byte     = uio_din;
+assign result_byte     = uio_din[7:0];
 
-assign sec_push        = uio_wr & uio_cs &  uio_cs_sec;
-assign sec_byte        = uio_din;
+assign sec_push        = wr_sec | hi_sec;
+assign sec_byte        = hi_sec ? uio_din[15:8] : uio_din[7:0];
 
 assign subcode_push    = uio_wr & uio_cs &  uio_cs_subcode;
-assign subcode_byte    = uio_din;
+assign subcode_byte    = uio_din[7:0];
 assign subcode_done    = xfer_end &              cs_subcode_d;
 
 assign nvr_addr        = nvr_addr_cnt;
+assign nvr_load_we     = wr_nvr | hi_nvr;
+assign nvr_load_din    = hi_nvr ? uio_din[15:8] : uio_din[7:0];
 assign nvr_clear_dirty = xfer_end & saw_read & cs_nvr_d;
 
 assign uio_dout        = uio_cs_nvr ? nvr_dout    :

--- a/rtl/fastchip.v
+++ b/rtl/fastchip.v
@@ -82,16 +82,7 @@ module fastchip
 	output        akiko_uio_req,
 	output        akiko_uio_sec_req,
 	output        akiko_uio_rx_busy,
-	output        akiko_uio_nvr_dirty,
-
-	input   [9:0] nvr_load_addr,
-	input   [7:0] nvr_load_din,
-	input         nvr_load_we,
-
-	input         hps_sec_dma_active,
-	input   [7:0] hps_sec_dma_byte,
-	input  [13:0] hps_sec_dma_addr,
-	input         hps_sec_dma_we
+	output        akiko_uio_nvr_dirty
 );
 
 localparam NATIVE_CD32 = 1;
@@ -123,6 +114,8 @@ wire  [7:0] akiko_uio_dout_byte;
 
 wire  [9:0] akiko_hps_nvr_addr;
 wire  [7:0] akiko_hps_nvr_dout;
+wire  [7:0] akiko_hps_nvr_load_din;
+wire        akiko_hps_nvr_load_we;
 wire        akiko_hps_nvr_clear_dirty;
 wire        akiko_hps_nvr_dirty;
 wire        akiko_hps_nvr_done;
@@ -166,13 +159,9 @@ akiko #(.NATIVE_CD32(NATIVE_CD32)) akiko
 	.hps_nvr_dout(akiko_hps_nvr_dout),
 	.hps_nvr_clear_dirty(akiko_hps_nvr_clear_dirty),
 	.hps_nvr_dirty(akiko_hps_nvr_dirty),
-	.nvr_load_addr(nvr_load_addr),
-	.nvr_load_din(nvr_load_din),
-	.nvr_load_we(nvr_load_we),
-	.hps_sec_dma_active(hps_sec_dma_active),
-	.hps_sec_dma_byte(hps_sec_dma_byte),
-	.hps_sec_dma_addr(hps_sec_dma_addr),
-	.hps_sec_dma_we(hps_sec_dma_we),
+	.nvr_load_addr(akiko_hps_nvr_addr),
+	.nvr_load_din(akiko_hps_nvr_load_din),
+	.nvr_load_we(akiko_hps_nvr_load_we),
 	.hps_subcode_push(akiko_hps_subcode_push),
 	.hps_subcode_byte(akiko_hps_subcode_byte),
 	.hps_subcode_done(akiko_hps_subcode_done)
@@ -188,7 +177,7 @@ akiko_hps_bridge akiko_hps_bridge
 	.uio_cs_subcode(akiko_uio_cs_subcode),
 	.uio_wr(akiko_uio_wr),
 	.uio_rd(akiko_uio_rd),
-	.uio_din(akiko_uio_din[7:0]),
+	.uio_din(akiko_uio_din),
 	.uio_dout(akiko_uio_dout_byte),
 	.cmd_pending(akiko_hps_cmd_pending),
 	.cmd_byte(akiko_hps_cmd_byte),
@@ -207,6 +196,8 @@ akiko_hps_bridge akiko_hps_bridge
 	.subcode_done(akiko_hps_subcode_done),
 	.nvr_addr(akiko_hps_nvr_addr),
 	.nvr_dout(akiko_hps_nvr_dout),
+	.nvr_load_din(akiko_hps_nvr_load_din),
+	.nvr_load_we(akiko_hps_nvr_load_we),
 	.nvr_clear_dirty(akiko_hps_nvr_clear_dirty),
 	.nvr_done(akiko_hps_nvr_done),
 	.nvr_dirty(akiko_hps_nvr_dirty),

--- a/rtl/sim/akiko/tb_akiko_hps_bridge.sv
+++ b/rtl/sim/akiko/tb_akiko_hps_bridge.sv
@@ -41,7 +41,7 @@ logic       uio_cs     = 0;
 logic       uio_cs_nvr = 0;
 logic       uio_wr     = 0;
 logic       uio_rd     = 0;
-logic [7:0] uio_din    = 0;
+logic [15:0] uio_din   = 0;
 wire  [7:0] uio_dout;
 wire        uio_req;
 
@@ -81,9 +81,7 @@ akiko #(.NATIVE_CD32(1)) u_dut (
 	.hps_rx_busy(),
 	.hps_nvr_addr(10'd0),
 	.hps_nvr_dout(), .hps_nvr_clear_dirty(1'b0), .hps_nvr_dirty(),
-	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0),
-	.hps_sec_dma_active(1'b0), .hps_sec_dma_byte(8'h00),
-	.hps_sec_dma_addr(14'd0), .hps_sec_dma_we(1'b0)
+	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0)
 );
 
 akiko_hps_bridge u_bridge (
@@ -98,6 +96,7 @@ akiko_hps_bridge u_bridge (
 	.sec_req(1'b0), .sec_status(8'h00),
 	.sec_push(), .sec_byte(), .sec_done(),
 	.nvr_addr(nvr_addr_w), .nvr_dout(nvr_dout_drv),
+	.nvr_load_din(nvr_din_w), .nvr_load_we(nvr_we_w),
 	.nvr_clear_dirty(nvr_clear_dirty_w), .nvr_done(nvr_done_w),
 	.nvr_dirty(nvr_dirty_drv), .nvr_dirty_out(),
 	.rx_busy(1'b0),
@@ -407,23 +406,19 @@ initial begin
 		@(posedge clk);
 		check_bit("I.nvr_addr_reset_pre", 1'b0, |nvr_addr_w);
 
-		@(posedge clk); uio_wr <= 1; uio_din <= 8'hDE;
+		@(posedge clk); uio_wr <= 1; uio_din <= 16'hADDE;
+		check_bit("I.nvr_lo_we",   1'b1, nvr_we_w);
+		check8   ("I.nvr_lo_din",  8'hDE, nvr_din_w);
 		@(posedge clk); uio_wr <= 0;
+		check_bit("I.nvr_hi_we",   1'b1, nvr_we_w);
+		check8   ("I.nvr_hi_din",  8'hAD, nvr_din_w);
 		@(posedge clk);
-		check_bit("I.nvr_addr_post0", 1'b1, nvr_addr_w == 10'd1);
+		check_bit("I.nvr_addr_post0", 1'b1, nvr_addr_w == 10'd2);
 
-		@(posedge clk); uio_wr <= 1; uio_din <= 8'hAD;
+		@(posedge clk); uio_wr <= 1; uio_din <= 16'hEFBE;
 		@(posedge clk); uio_wr <= 0;
 		@(posedge clk);
-		check_bit("I.nvr_addr_post1", 1'b1, nvr_addr_w == 10'd2);
-
-		@(posedge clk); uio_wr <= 1; uio_din <= 8'hBE;
-		@(posedge clk); uio_wr <= 0;
-		@(posedge clk);
-		@(posedge clk); uio_wr <= 1; uio_din <= 8'hEF;
-		@(posedge clk); uio_wr <= 0;
-		@(posedge clk);
-		check_bit("I.nvr_addr_post3", 1'b1, nvr_addr_w == 10'd4);
+		check_bit("I.nvr_addr_post1", 1'b1, nvr_addr_w == 10'd4);
 
 		check_bit("I.no_clear_during_write", 1'b0, nvr_clear_dirty_seen);
 

--- a/rtl/sim/akiko/tb_akiko_pbx_dma.sv
+++ b/rtl/sim/akiko/tb_akiko_pbx_dma.sv
@@ -35,10 +35,6 @@ logic       hps_sec_push = 0;
 logic [7:0] hps_sec_byte = 0;
 logic       hps_sec_done = 0;
 
-logic        hps_sec_dma_active = 0;
-logic  [7:0] hps_sec_dma_byte_d = 0;
-logic [13:0] hps_sec_dma_addr_d = 0;
-logic        hps_sec_dma_we_d   = 0;
 
 akiko #(.NATIVE_CD32(1)) u_dut (
 	.clk(clk), .reset(reset),
@@ -60,11 +56,7 @@ akiko #(.NATIVE_CD32(1)) u_dut (
 	.hps_rx_busy(),
 	.hps_nvr_addr(10'd0),
 	.hps_nvr_dout(), .hps_nvr_clear_dirty(1'b0), .hps_nvr_dirty(),
-	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0),
-	.hps_sec_dma_active(hps_sec_dma_active),
-	.hps_sec_dma_byte(hps_sec_dma_byte_d),
-	.hps_sec_dma_addr(hps_sec_dma_addr_d),
-	.hps_sec_dma_we(hps_sec_dma_we_d)
+	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0)
 );
 
 localparam [31:0] CDINT_PBX       = 32'h04000000;
@@ -168,23 +160,6 @@ task automatic push_sector(input [7:0] seed);
 	hps_sec_done <= 1'b1;
 	@(posedge clk);
 	hps_sec_done <= 1'b0;
-	@(posedge clk);
-endtask
-
-task automatic push_sector_dma(input [7:0] seed);
-	@(posedge clk);
-	hps_sec_dma_active <= 1'b1;
-	@(posedge clk);
-	for (int i = 0; i < 2352; i++) begin
-		hps_sec_dma_addr_d <= i[13:0];
-		hps_sec_dma_byte_d <= seed + i[7:0];
-		hps_sec_dma_we_d   <= 1'b1;
-		@(posedge clk);
-		hps_sec_dma_we_d   <= 1'b0;
-	end
-	hps_sec_dma_active <= 1'b0;
-	hps_sec_dma_addr_d <= 14'd0;
-	hps_sec_dma_byte_d <= 8'h00;
 	@(posedge clk);
 endtask
 
@@ -415,18 +390,6 @@ initial begin
 	check8("G.cmdlen_zero", 8'd0, {2'h0, u_dut.g_cd.cdrom_command_length});
 	check8("G.txinx_zero",  8'd0, u_dut.g_cd.cdcomtxinx);
 	check_slot("G.slot0", 'h10000, 8'hB0, 8'd0);
-
-	$display("--- Test H: fast sector DMA (push_sector_dma) ---");
-	set_config(32'h0);
-	repeat(10) @(posedge clk);
-	set_config(CFG_ENABLE | CFG_PBX);
-	set_addressdata(24'h020000);
-	set_misc_base(24'h004000);
-	push_sector_dma(8'hC0);
-	write_pbx(16'h0001);
-	wait_sector_inc(8'd0, 20000, cyc);
-	$display("    H: sector_inc in %0d cycles", cyc);
-	check_slot("H.slot0", 'h20000, 8'hC0, 8'd0);
 
 	$display("------------------------------------");
 	$display("checks=%0d errors=%0d", checks, errs);

--- a/rtl/sim/akiko/tb_akiko_regs.sv
+++ b/rtl/sim/akiko/tb_akiko_regs.sv
@@ -47,9 +47,7 @@ akiko #(.NATIVE_CD32(0)) u_dut0 (
 	.hps_rx_busy(),
 	.hps_nvr_addr(10'd0),
 	.hps_nvr_dout(), .hps_nvr_clear_dirty(1'b0), .hps_nvr_dirty(),
-	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0),
-	.hps_sec_dma_active(1'b0), .hps_sec_dma_byte(8'h00),
-	.hps_sec_dma_addr(14'd0), .hps_sec_dma_we(1'b0)
+	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0)
 );
 
 akiko #(.NATIVE_CD32(1)) u_dut1 (
@@ -68,9 +66,7 @@ akiko #(.NATIVE_CD32(1)) u_dut1 (
 	.hps_rx_busy(),
 	.hps_nvr_addr(10'd0),
 	.hps_nvr_dout(), .hps_nvr_clear_dirty(1'b0), .hps_nvr_dirty(),
-	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0),
-	.hps_sec_dma_active(1'b0), .hps_sec_dma_byte(8'h00),
-	.hps_sec_dma_addr(14'd0), .hps_sec_dma_we(1'b0)
+	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0)
 );
 
 localparam [31:0] CDINT_SUBCODE   = 32'h80000000;

--- a/rtl/sim/akiko/tb_akiko_txrx_dma.sv
+++ b/rtl/sim/akiko/tb_akiko_txrx_dma.sv
@@ -46,9 +46,7 @@ akiko #(.NATIVE_CD32(1)) u_dut (
 	.hps_rx_busy(),
 	.hps_nvr_addr(10'd0),
 	.hps_nvr_dout(), .hps_nvr_clear_dirty(1'b0), .hps_nvr_dirty(),
-	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0),
-	.hps_sec_dma_active(1'b0), .hps_sec_dma_byte(8'h00),
-	.hps_sec_dma_addr(14'd0), .hps_sec_dma_we(1'b0)
+	.nvr_load_addr(10'd0), .nvr_load_din(8'h00), .nvr_load_we(1'b0)
 );
 
 localparam [31:0] CDINT_DRIVEXMIT = 32'h40000000;


### PR DESCRIPTION
Follow-up to #217. The Akiko NVRAM image and the CD sector stream reached the
core over the `hps_io` virtual-disk interface, so `Minimig.sv` carried an
`img_mounted`/`sd_lba`/`sd_rd_nvr` block and instantiated `hps_io` with
`VDNUM`/`BLKSZ` purely to serve two CD32/CDTV-only transports. Stock
`Minimig.sv` declares no `sd_*`/`img_*` ports at all.

Both channels now ride the **ext bus**, alongside the Akiko command, subcode,
trace and sector sub-channels that already use it — one mechanism for the
CD32/CDTV host path instead of two, and the virtual-disk plumbing goes away.

### What changes

- `akiko_hps_bridge` takes `uio_din` as 16 bits and unpacks two bytes per
  ext-bus word, low byte first: a write strobe emits the low byte immediately
  and the high byte on the following cycle, advancing the NVRAM/sector address
  by two.
- The bridge gains the NVRAM **write** direction (`nvr_load_din`/`nvr_load_we`),
  so the image is pushed in over the same path that reads it back out.
- `akiko.v` loses the separate `hps_sec_dma_*` port group and its mux; the push
  path is now the only sector writer.
- `fastchip.v` drops the `nvr_load_*`/`hps_sec_dma_*` inputs and widens
  `uio_din`.
- `Minimig.sv` drops the virtual-disk block and the `sd_*`/`img_*` connections
  and instantiates `hps_io` as stock does.
- Benches updated for the 16-bit ingest and the removed port groups.

### Why the two-byte-per-word pump is safe

`io_strobe` is a one-cycle `clk_sys` pulse (`sys_top.v`), and `hps_io`'s own
`b_wr` three-stage shift cascade already assumes strobes are at least three
`clk_sys` cycles apart — which holds for the fastest block writes. So the
follow-on cycle used to emit the high byte cannot collide with the next strobe.

### Companion change

Needs the userspace side: **MiSTer-devel/Main_MiSTer#1267**. The two must land
together — the sub-channels take 16-bit words after this change.

### Testing

Elaborates clean in Quartus 17.0.2 (0 errors). Full fit built and run on a
DE10-Nano; the synthesizable RTL here is byte-identical to the bitstream that
was tested. Note the CD32 boot path also needs
`2f1f722` (A2065 DDR3 clear) on the Main_MiSTer side — without it the core's
state depends on which core was loaded previously.

Draft — happy to split the bench updates out, or to keep a compatibility path
for the old port groups if you'd rather not remove them in one go.
