### PR TITLE
CDTV memory card at $E00000

### DIFF
--- a/Minimig.sv
+++ b/Minimig.sv
@@ -126,7 +126,9 @@ wire        cdtv_cs;
 wire        cdtv_cs_sec;
 wire        cdtv_cs_stch;
 wire        cdtv_cs_nvr;
+wire        cdtv_cs_card;
 wire        cdtv_nvr_dirty;
+wire        cdtv_card_dirty;
 wire        cdtv_req;
 
 wire        akiko_dma_req;
@@ -823,6 +825,7 @@ minimig minimig
 	.cdtv_cs_sec         (cdtv_cs_sec          ),
 	.cdtv_cs_stch        (cdtv_cs_stch         ),
 	.cdtv_cs_nvr         (cdtv_cs_nvr          ),
+	.cdtv_cs_card        (cdtv_cs_card         ),
 	.cdtv_wr             (cdtv_wr              ),
 	.cdtv_rd             (cdtv_rd              ),
 	.cdtv_uio_din        (cdtv_dout            ),
@@ -841,6 +844,7 @@ minimig minimig
 	.cdtv_dma_ack        (cdtv_dma_ack         ),
 
 	.cdtv_nvr_dirty      (cdtv_nvr_dirty       ),
+	.cdtv_card_dirty     (cdtv_card_dirty      ),
 
 	.cdtv_cdda_volume    (cdtv_cdda_volume     ),
 

--- a/hps_ext.v
+++ b/hps_ext.v
@@ -81,8 +81,10 @@ module hps_ext
 	output reg        cdtv_cs_sec,
 	output reg        cdtv_cs_stch,
 	output reg        cdtv_cs_nvr,
+	output reg        cdtv_cs_card,
 	input             cdtv_req,
-	input             cdtv_nvr_dirty
+	input             cdtv_nvr_dirty,
+	input             cdtv_card_dirty
 );
 
 assign EXT_BUS[15:0] = io_fpga ? fpga_dout : io_dout;
@@ -134,6 +136,7 @@ always@(posedge clk_sys) begin : main_proc
 		cdtv_cs_sec <= 0;
 		cdtv_cs_stch <= 0;
 		cdtv_cs_nvr <= 0;
+		cdtv_cs_card <= 0;
 		if(cmd == 'h2D) sset <= 1;
 	end
 	else if(io_strobe) begin
@@ -156,13 +159,14 @@ always@(posedge clk_sys) begin : main_proc
 			cdtv_cs          <= (io_din[15:9] == 7'b1111100) && !io_din[7] && !io_din[6] && !io_din[5];
 			cdtv_cs_sec      <= (io_din[15:9] == 7'b1111100) && !io_din[7] && !io_din[6] &&  io_din[5];
 			cdtv_cs_stch     <= (io_din[15:9] == 7'b1111100) && !io_din[7] &&  io_din[6];
-			cdtv_cs_nvr      <= (io_din[15:9] == 7'b1111100) &&  io_din[7];
+			cdtv_cs_nvr      <= (io_din[15:9] == 7'b1111100) &&  io_din[7] && !io_din[6];
+			cdtv_cs_card     <= (io_din[15:9] == 7'b1111100) &&  io_din[7] &&  io_din[6];
 		end
 
 		if(byte_cnt == 0) begin
 			cmd <= io_din;
 			dout_en <= (io_din >= EXT_CMD_MIN && io_din <= EXT_CMD_MAX) || (io_din >= EXT_CMD_MIN2 && io_din <= EXT_CMD_MAX2);
-			if(io_din == 'h63) io_dout <= {3'b000, cdtv_nvr_dirty, akiko_req, akiko_sec_req, akiko_rx_busy, cdda_req, akiko_nvr_dirty, cdtv_req, ide_req};
+			if(io_din == 'h63) io_dout <= {2'b00, cdtv_card_dirty, cdtv_nvr_dirty, akiko_req, akiko_sec_req, akiko_rx_busy, cdda_req, akiko_nvr_dirty, cdtv_req, ide_req};
 			if(io_din == UIO_GET_VMODE) io_dout <= 1;
 		end else begin
 			case(cmd)
@@ -229,7 +233,7 @@ always@(posedge clk_sys) begin : main_proc
 						cdda_wr  <= cdda_cs;
 						ide_wr   <= ide_cs;
 						akiko_wr <= akiko_cs;
-						cdtv_wr  <= cdtv_cs | cdtv_cs_stch | cdtv_cs_sec | cdtv_cs_nvr;
+						cdtv_wr  <= cdtv_cs | cdtv_cs_stch | cdtv_cs_sec | cdtv_cs_nvr | cdtv_cs_card;
 					end
 				end
 
@@ -242,7 +246,7 @@ always@(posedge clk_sys) begin : main_proc
 						io_dout  <= akiko_din;
 						akiko_rd <= 1;
 					end
-					if(byte_cnt >= 3 && (cdtv_cs | cdtv_cs_stch | cdtv_cs_nvr)) begin
+					if(byte_cnt >= 3 && (cdtv_cs | cdtv_cs_stch | cdtv_cs_nvr | cdtv_cs_card)) begin
 						io_dout <= cdtv_din;
 						cdtv_rd <= 1;
 					end

--- a/rtl/cdtv_bridge.v
+++ b/rtl/cdtv_bridge.v
@@ -34,6 +34,7 @@ module cdtv_bridge
 	input             uio_cs_sec,
 	input             uio_cs_stch,
 	input             uio_cs_nvr,
+	input             uio_cs_card,
 	input             uio_wr,
 	input             uio_rd,
 	input      [15:0] uio_din,
@@ -45,6 +46,12 @@ module cdtv_bridge
 	output      [7:0] nvr_load_din,
 	output            nvr_load_we,
 	output            nvr_clear_dirty,
+
+	output     [12:0] card_addr,
+	input       [7:0] card_dout,
+	output      [7:0] card_load_din,
+	output            card_load_we,
+	output            card_clear_dirty,
 
 	input             subq_push,
 	input       [7:0] subq_byte,
@@ -255,7 +262,38 @@ assign nvr_load_we     = wr_nvr | hi_nvr;
 assign nvr_load_din    = hi_nvr ? uio_din[15:8] : uio_din[7:0];
 assign nvr_clear_dirty = cs_nvr_d & ~uio_cs_nvr & saw_nvr_read;
 
+reg [12:0] card_addr_cnt;
+reg        cs_card_d;
+reg        hi_card;
+reg        saw_card_read;
+wire       wr_card = uio_wr & uio_cs_card;
+
+always @(posedge clk) begin
+	if (reset) begin
+		card_addr_cnt <= 13'd0;
+		cs_card_d     <= 1'b0;
+		hi_card       <= 1'b0;
+		saw_card_read <= 1'b0;
+	end else begin
+		hi_card   <= wr_card;
+		cs_card_d <= uio_cs_card;
+		if (uio_cs_card & ~cs_card_d) begin
+			card_addr_cnt <= 13'd0;
+			saw_card_read <= 1'b0;
+		end else if ((uio_rd & uio_cs_card) | wr_card | hi_card) begin
+			card_addr_cnt <= card_addr_cnt + 13'd1;
+		end
+		if (uio_rd & uio_cs_card) saw_card_read <= 1'b1;
+	end
+end
+
+assign card_addr        = card_addr_cnt;
+assign card_load_we     = wr_card | hi_card;
+assign card_load_din    = hi_card ? uio_din[15:8] : uio_din[7:0];
+assign card_clear_dirty = cs_card_d & ~uio_cs_card & saw_card_read;
+
 assign uio_dout = uio_cs_nvr  ? {8'h00, nvr_dout} :
+                  uio_cs_card ? {8'h00, card_dout} :
                   uio_cs_stch ? {15'h0000, stch_ack} : {8'h00, cmd_in_byte};
 assign uio_req  = cmd_in_pending;
 

--- a/rtl/cdtv_nvram.v
+++ b/rtl/cdtv_nvram.v
@@ -13,6 +13,9 @@
 // GNU General Public License for more details.
 
 module cdtv_nvram
+#(
+	parameter ADDR_W = 14
+)
 (
 	input             clk,
 	input             reset,
@@ -25,122 +28,85 @@ module cdtv_nvram
 	input             hwr,
 	input             lwr,
 
-	input      [13:0] hps_load_addr,
-	input       [7:0] hps_load_din,
-	input             hps_load_we,
+	input  [ADDR_W-1:0] hps_load_addr,
+	input         [7:0] hps_load_din,
+	input               hps_load_we,
 
-	input      [13:0] hps_save_addr,
-	output      [7:0] hps_save_dout,
+	input  [ADDR_W-1:0] hps_save_addr,
+	output        [7:0] hps_save_dout,
 
 	output reg        dirty = 1'b0,
 	input             clear_dirty
 );
 
-wire [12:0] cpu_waddr = addr[13:1];
-wire [12:0] hps_waddr = hps_load_addr[13:1];
-wire        hps_byte  = hps_load_addr[0];
+localparam WORD_W = ADDR_W - 1;
+localparam WORDS  = 1 << WORD_W;
 
-wire [12:0] write_addr    = hps_load_we ? hps_waddr : cpu_waddr;
-wire [15:0] write_data    = hps_load_we ? {hps_load_din, hps_load_din} : din;
-wire [1:0]  write_byteena = hps_load_we ? {~hps_byte, hps_byte}
-                                        : {sel & hwr, sel & lwr};
-wire        write_we      = hps_load_we | (sel & (hwr | lwr));
+wire [WORD_W-1:0] cpu_addr    = addr[ADDR_W-1:1];
+wire        [1:0] cpu_byteena = {sel & hwr, sel & lwr};
+wire              cpu_we      = sel & (hwr | lwr);
 
-altsyncram nvram_inst (
-	.address_a      (write_addr),
-	.clock0         (clk),
-	.data_a         (write_data),
-	.byteena_a      (write_byteena),
-	.wren_a         (write_we),
-	.address_b      (cpu_waddr),
-	.q_b            (dout),
-	.aclr0          (1'b0),
-	.aclr1          (1'b0),
-	.addressstall_a (1'b0),
-	.addressstall_b (1'b0),
-	.byteena_b      (1'b1),
-	.clock1         (1'b1),
-	.clocken0       (1'b1),
-	.clocken1       (1'b1),
-	.clocken2       (1'b1),
-	.clocken3       (1'b1),
-	.data_b         (16'h0000),
-	.eccstatus      (),
-	.q_a            (),
-	.rden_a         (1'b1),
-	.rden_b         (1'b1),
-	.wren_b         (1'b0)
-);
-defparam
-	nvram_inst.address_aclr_b                  = "NONE",
-	nvram_inst.address_reg_b                   = "CLOCK0",
-	nvram_inst.clock_enable_input_a            = "BYPASS",
-	nvram_inst.clock_enable_input_b            = "BYPASS",
-	nvram_inst.clock_enable_output_b           = "BYPASS",
-	nvram_inst.intended_device_family          = "Cyclone V",
-	nvram_inst.lpm_type                        = "altsyncram",
-	nvram_inst.numwords_a                      = 8192,
-	nvram_inst.numwords_b                      = 8192,
-	nvram_inst.operation_mode                  = "DUAL_PORT",
-	nvram_inst.outdata_aclr_b                  = "NONE",
-	nvram_inst.outdata_reg_b                   = "UNREGISTERED",
-	nvram_inst.power_up_uninitialized          = "FALSE",
-	nvram_inst.ram_block_type                  = "M10K",
-	nvram_inst.read_during_write_mode_mixed_ports = "OLD_DATA",
-	nvram_inst.widthad_a                       = 13,
-	nvram_inst.widthad_b                       = 13,
-	nvram_inst.width_a                         = 16,
-	nvram_inst.width_b                         = 16,
-	nvram_inst.width_byteena_a                 = 2;
+wire              hps_byte    = hps_load_addr[0];
+wire [WORD_W-1:0] hps_addr    = hps_load_we ? hps_load_addr[ADDR_W-1:1] : hps_save_addr[ADDR_W-1:1];
+wire       [15:0] hps_data    = {hps_load_din, hps_load_din};
+wire        [1:0] hps_byteena = {~hps_byte, hps_byte};
 
 wire [15:0] save_q;
 
-altsyncram nvram_save_inst (
-	.address_a      (write_addr),
+altsyncram nvram_inst (
+	.address_a      (cpu_addr),
 	.clock0         (clk),
-	.data_a         (write_data),
-	.byteena_a      (write_byteena),
-	.wren_a         (write_we),
-	.address_b      (hps_save_addr[13:1]),
+	.data_a         (din),
+	.byteena_a      (cpu_byteena),
+	.wren_a         (cpu_we),
+	.q_a            (dout),
+	.address_b      (hps_addr),
+	.data_b         (hps_data),
+	.byteena_b      (hps_byteena),
+	.wren_b         (hps_load_we),
 	.q_b            (save_q),
 	.aclr0          (1'b0),
 	.aclr1          (1'b0),
 	.addressstall_a (1'b0),
 	.addressstall_b (1'b0),
-	.byteena_b      (1'b1),
 	.clock1         (1'b1),
 	.clocken0       (1'b1),
 	.clocken1       (1'b1),
 	.clocken2       (1'b1),
 	.clocken3       (1'b1),
-	.data_b         (16'h0000),
 	.eccstatus      (),
-	.q_a            (),
 	.rden_a         (1'b1),
-	.rden_b         (1'b1),
-	.wren_b         (1'b0)
+	.rden_b         (1'b1)
 );
 defparam
-	nvram_save_inst.address_aclr_b                  = "NONE",
-	nvram_save_inst.address_reg_b                   = "CLOCK0",
-	nvram_save_inst.clock_enable_input_a            = "BYPASS",
-	nvram_save_inst.clock_enable_input_b            = "BYPASS",
-	nvram_save_inst.clock_enable_output_b           = "BYPASS",
-	nvram_save_inst.intended_device_family          = "Cyclone V",
-	nvram_save_inst.lpm_type                        = "altsyncram",
-	nvram_save_inst.numwords_a                      = 8192,
-	nvram_save_inst.numwords_b                      = 8192,
-	nvram_save_inst.operation_mode                  = "DUAL_PORT",
-	nvram_save_inst.outdata_aclr_b                  = "NONE",
-	nvram_save_inst.outdata_reg_b                   = "UNREGISTERED",
-	nvram_save_inst.power_up_uninitialized          = "FALSE",
-	nvram_save_inst.ram_block_type                  = "M10K",
-	nvram_save_inst.read_during_write_mode_mixed_ports = "OLD_DATA",
-	nvram_save_inst.widthad_a                       = 13,
-	nvram_save_inst.widthad_b                       = 13,
-	nvram_save_inst.width_a                         = 16,
-	nvram_save_inst.width_b                         = 16,
-	nvram_save_inst.width_byteena_a                 = 2;
+	nvram_inst.address_reg_b                      = "CLOCK0",
+	nvram_inst.byteena_reg_b                      = "CLOCK0",
+	nvram_inst.indata_reg_b                       = "CLOCK0",
+	nvram_inst.wrcontrol_wraddress_reg_b          = "CLOCK0",
+	nvram_inst.clock_enable_input_a               = "BYPASS",
+	nvram_inst.clock_enable_input_b               = "BYPASS",
+	nvram_inst.clock_enable_output_a              = "BYPASS",
+	nvram_inst.clock_enable_output_b              = "BYPASS",
+	nvram_inst.intended_device_family             = "Cyclone V",
+	nvram_inst.lpm_type                           = "altsyncram",
+	nvram_inst.numwords_a                         = WORDS,
+	nvram_inst.numwords_b                         = WORDS,
+	nvram_inst.operation_mode                     = "BIDIR_DUAL_PORT",
+	nvram_inst.outdata_aclr_a                     = "NONE",
+	nvram_inst.outdata_aclr_b                     = "NONE",
+	nvram_inst.outdata_reg_a                      = "UNREGISTERED",
+	nvram_inst.outdata_reg_b                      = "UNREGISTERED",
+	nvram_inst.power_up_uninitialized             = "FALSE",
+	nvram_inst.ram_block_type                     = "M10K",
+	nvram_inst.read_during_write_mode_mixed_ports = "OLD_DATA",
+	nvram_inst.read_during_write_mode_port_a      = "NEW_DATA_NO_NBE_READ",
+	nvram_inst.read_during_write_mode_port_b      = "NEW_DATA_NO_NBE_READ",
+	nvram_inst.widthad_a                          = WORD_W,
+	nvram_inst.widthad_b                          = WORD_W,
+	nvram_inst.width_a                            = 16,
+	nvram_inst.width_b                            = 16,
+	nvram_inst.width_byteena_a                    = 2,
+	nvram_inst.width_byteena_b                    = 2;
 
 assign hps_save_dout = hps_save_addr[0] ? save_q[7:0] : save_q[15:8];
 

--- a/rtl/gary.v
+++ b/rtl/gary.v
@@ -106,6 +106,7 @@ module gary
 
 	output       sel_cdtv,
 	output       sel_cdtv_nvram,
+	output       sel_cdtv_card,
 
 	output reg   rom_readonly = 0 //when zero allows to write to $fc-$ff, blocks effect of kick256kmirror.  
 );
@@ -134,6 +135,7 @@ assign ram_lwr = dbr ?  dbwe : cpu_lwr;
 wire kick_mirror_a8 = cpu_address_in[23:19] == 5'b1010_1;
 wire kick_mirror_b0 = cpu_address_in[23:19] == 5'b1011_0;
 wire kick_mirror_f0 = cdtv_mode && cpu_address_in[23:19] == 5'b1111_0;
+wire cdtv_card_win  = cdtv_mode && cpu_address_in[23:19] == 5'b1110_0 && !cpu_hlt;
 wire [4:0] cpu_addr_hi_remap = kick_mirror_a8 ? 5'b1111_1 :
                                kick_mirror_b0 ? 5'b1110_0 :
                                kick_mirror_f0 ? 5'b1110_0 :
@@ -175,7 +177,7 @@ begin
 		sel_slow[1] = t_sel_slow[1];
 		sel_slow[2] = t_sel_slow[2];
 		sel_kick    = (cpu_address_in[23:19]==5'b1111_1 && (cpu_rd || cpu_hlt || (!rom_readonly && cpu_address_in[18])))  || (cpu_rd && ovl && cpu_address_in[23:19]==5'b0000_0) || (cpu_rd && kick_mirror_a8);
-		sel_kick1mb = (cpu_address_in[23:19]==5'b1110_0 && (cpu_rd || cpu_hlt)) || (cpu_rd && kick_mirror_b0) || (cpu_rd && kick_mirror_f0);
+		sel_kick1mb = (cpu_address_in[23:19]==5'b1110_0 && ((cpu_rd && !cdtv_card_win) || cpu_hlt)) || (cpu_rd && kick_mirror_b0) || (cpu_rd && kick_mirror_f0);
 		sel_kick256kmirror = cpu_address_in[23:19]==5'b1111_1 &&  cpu_rd && rom_readonly && !cpu_hlt && bootrom;
 	end
 end
@@ -199,6 +201,7 @@ assign sel_a2065   = a2065_ena && cpu_address_in[23:16]==a2065_base;
 
 assign sel_cdtv       = cdtv_mode && cpu_address_in[23:16]==cdtv_base;
 assign sel_cdtv_nvram = cdtv_mode && cpu_address_in[23:15]==9'b1101_1100_1;
+assign sel_cdtv_card  = cdtv_card_win;
 
 //data bus slow down
 assign dbs = cpu_address_in[23:21]==3'b000 || cpu_address_in[23:20]==4'b1100 || cpu_address_in[23:19]==5'b1101_0 || cpu_address_in[23:16]==8'b1101_1111;

--- a/rtl/minimig.v
+++ b/rtl/minimig.v
@@ -262,6 +262,7 @@ module minimig
 	input         cdtv_cs_sec,
 	input         cdtv_cs_stch,
 	input         cdtv_cs_nvr,
+	input         cdtv_cs_card,
 	input         cdtv_wr,
 	input         cdtv_rd,
 	input  [15:0] cdtv_uio_din,
@@ -280,6 +281,7 @@ module minimig
 	input         cdtv_dma_ack,
 
 	output        cdtv_nvr_dirty,
+	output        cdtv_card_dirty,
 
 	output  [9:0] cdtv_cdda_volume,
 
@@ -369,6 +371,7 @@ wire        sel_cia_b;			//cia B select
 	wire        sel_a2065;
 wire        sel_cdtv;
 wire        sel_cdtv_nvram;
+wire        sel_cdtv_card;
 wire [15:0] cdtv_bridge_dout;
 wire        cdtv_bridge_selack;
 wire [15:0] cdtv_nvr_dout;
@@ -377,6 +380,12 @@ wire  [7:0] cdtv_nvr_load_din;
 wire        cdtv_nvr_load_we;
 wire  [7:0] cdtv_nvr_save_dout;
 wire        cdtv_nvr_clear_dirty;
+wire [15:0] cdtv_card_dout;
+wire [12:0] cdtv_card_addr;
+wire  [7:0] cdtv_card_load_din;
+wire        cdtv_card_load_we;
+wire  [7:0] cdtv_card_save_dout;
+wire        cdtv_card_clear_dirty;
 wire        cdtv_irq_w;
 wire        int2;					//intterrupt 2
 wire        int3;					//intterrupt 3 
@@ -876,6 +885,7 @@ gary GARY1
 	.sel_a2065(sel_a2065),
 	.sel_cdtv(sel_cdtv),
 	.sel_cdtv_nvram(sel_cdtv_nvram),
+	.sel_cdtv_card(sel_cdtv_card),
 	.reset(reset),
 	.clk(clk),
 	.rom_readonly(rom_readonly),
@@ -1027,6 +1037,7 @@ cdtv_bridge cdtv_bridge_inst
 	.uio_cs_sec      (cdtv_cs_sec          ),
 	.uio_cs_stch     (cdtv_cs_stch         ),
 	.uio_cs_nvr      (cdtv_cs_nvr          ),
+	.uio_cs_card     (cdtv_cs_card         ),
 	.uio_wr          (cdtv_wr              ),
 	.uio_rd          (cdtv_rd              ),
 	.uio_din         (cdtv_uio_din         ),
@@ -1038,6 +1049,12 @@ cdtv_bridge cdtv_bridge_inst
 	.nvr_load_din    (cdtv_nvr_load_din    ),
 	.nvr_load_we     (cdtv_nvr_load_we     ),
 	.nvr_clear_dirty (cdtv_nvr_clear_dirty ),
+
+	.card_addr        (cdtv_card_addr       ),
+	.card_dout        (cdtv_card_save_dout  ),
+	.card_load_din    (cdtv_card_load_din   ),
+	.card_load_we     (cdtv_card_load_we    ),
+	.card_clear_dirty (cdtv_card_clear_dirty),
 
 	.subq_push       (cdtv_subq_push       ),
 	.subq_byte       (cdtv_subq_byte       ),
@@ -1077,8 +1094,32 @@ cdtv_nvram cdtv_nvram_inst
 	.clear_dirty     (cdtv_nvr_clear_dirty )
 );
 
-assign cdtv_din    = sel_cdtv_nvram ? cdtv_nvr_dout : cdtv_bridge_dout;
-assign cdtv_selack = cdtv_bridge_selack | sel_cdtv_nvram;
+cdtv_nvram #(.ADDR_W(13)) cdtv_card_inst
+(
+	.clk             (clk                   ),
+	.reset           (reset                 ),
+
+	.sel             (sel_cdtv_card         ),
+	.addr            (cpu_address_out       ),
+	.din             (cpu_data_out          ),
+	.dout            (cdtv_card_dout        ),
+	.rd              (cpu_rd                ),
+	.hwr             (cpu_hwr               ),
+	.lwr             (cpu_lwr               ),
+
+	.hps_load_addr   (cdtv_card_addr        ),
+	.hps_load_din    (cdtv_card_load_din    ),
+	.hps_load_we     (cdtv_card_load_we     ),
+
+	.hps_save_addr   (cdtv_card_addr        ),
+	.hps_save_dout   (cdtv_card_save_dout   ),
+
+	.dirty           (cdtv_card_dirty       ),
+	.clear_dirty     (cdtv_card_clear_dirty )
+);
+
+assign cdtv_din    = sel_cdtv_nvram ? cdtv_nvr_dout : sel_cdtv_card ? cdtv_card_dout : cdtv_bridge_dout;
+assign cdtv_selack = cdtv_bridge_selack | sel_cdtv_nvram | sel_cdtv_card;
 //-------------------------------------------------------------------------------------
 
 //data multiplexer


### PR DESCRIPTION
Adds the CDTV memory card — the 8 KB battery-backed RAM at `$E00000` that the
extended ROM sizes on boot and titles use for saved games.

The card is a byte-wide dual-port RAM in `rtl/cdtv_nvram.v`, decoded in
`rtl/gary.v` and wired through `rtl/minimig.v`. `$E00000` is inside the region
`sel_kick1mb` mirrors up to `$F00000`; the alias does not exist on real
hardware and the ROM stays reachable at its own address, so the card takes
priority there. `cpu_hlt` still points the region at the ROM, leaving the
host's kickstart upload unaffected.

Address bits above 8 KB are deliberately left undecoded. The extended ROM sizes
the card with a 2 KB-granular alias walk, and the aliasing is what terminates
that walk at exactly 8 KB.

Host transport reuses the NVRAM pattern on a new ext-bus sub-channel at
`0xF8C0`, selected by CDTV address bit 6 next to the existing NVRAM bit 7, with
its own dirty flag in status bit 13.

Switching `rtl/cdtv_nvram.v` to `BIDIR_DUAL_PORT` drops the mirror registers the
old style needed, so the card costs **net −8 M10K** despite adding 8 KB of
storage.

Hardware-verified on the shared rig: the ROM formats a blank card on first
insert, and the per-disc `.card` file persists across mounts.

Host counterpart: MiSTer-devel/Main_MiSTer PR for `pr-cdtv-memory-card-play`
(the first of its two commits). Both halves must land together.
