### PR TITLE
cdtv: route CDTV register accesses through the chip bus on TG68K

### DIFF
--- a/rtl/chipdma_arb.v
+++ b/rtl/chipdma_arb.v
@@ -152,6 +152,7 @@ memory_router u_router
 	.ckick         (1'b0),
 	.wr            (1'b0),
 	.bootrom       (1'b0),
+	.cdtv_mode     (1'b0),
 	.z2ram_ena     (z2ram_ena),
 	.z3ram_base0   (z3ram_base0),
 	.z3ram_ena0    (z3ram_ena0),

--- a/rtl/cpu_wrapper.v
+++ b/rtl/cpu_wrapper.v
@@ -113,6 +113,7 @@ memory_router u_memory_router
 	.ckick         (ckick         ),
 	.wr            (wr            ),
 	.bootrom       (bootrom       ),
+	.cdtv_mode     (cdtv_mode     ),
 	.z2ram_ena     (z2ram_ena     ),
 	.z3ram_base0   (z3ram_base0   ),
 	.z3ram_ena0    (z3ram_ena0    ),
@@ -305,7 +306,7 @@ always @(posedge clk) begin
 end
 
 wire stock_speed   = cachecfg[3];
-wire clkena_p_base = ~cpu_req | chipready | ramready | fastchip_ready | cdtv_selack;
+wire clkena_p_base = ~cpu_req | chipready | ramready | fastchip_ready;
 
 reg [3:0] cooldown;
 always @(posedge clk) begin
@@ -318,7 +319,7 @@ wire clkena_p_throttled = clkena_p_base & (cooldown == 4'd0);
 reg       chipreq;
 reg [2:0] cpu_ipl;
 always @(posedge clk) begin
-	chipreq <= cpu_req & ~ramsel & ~fastchip_selack & ~cdtv_selack;
+	chipreq <= cpu_req & ~ramsel & ~fastchip_selack;
 	cpu_ipl <= ipl_i;
 end
 

--- a/rtl/memory_router.v
+++ b/rtl/memory_router.v
@@ -9,6 +9,7 @@ module memory_router
 	input         wr,
 
 	input         bootrom,
+	input         cdtv_mode,
 
 	input         z2ram_ena,
 	input   [4:0] z3ram_base0,
@@ -37,7 +38,7 @@ assign sel_dd       = (cpu_addr[31:16] == 16'h00DD) && (cpu_addr[15:13] == 3'b01
 assign sel_rtg      = (cpu_addr[31:24] == 8'h02);
 
 // don't sel_kickram when writing
-assign sel_kickram   = !cpu_addr[31:24] && (&cpu_addr[23:19] || (cpu_addr[23:19] == 5'b11100) || (cpu_addr[23:19] == 5'b10101) || (cpu_addr[23:19] == 5'b10110)) && ckick && wr;
+assign sel_kickram   = !cpu_addr[31:24] && (&cpu_addr[23:19] || (!cdtv_mode && cpu_addr[23:19] == 5'b11100) || (cpu_addr[23:19] == 5'b10101) || (cpu_addr[23:19] == 5'b10110)) && ckick && wr;
 assign sel_kicklower = !cpu_addr[31:24] && (cpu_addr[23:18] == 6'b111110);
 assign sel_chipram   = !cpu_addr[31:21] && cchip;
 


### PR DESCRIPTION
Targets the CD32/CDTV + 68020 combination.

Full narrative is in the commit message (`cdtv: route CDTV register accesses through the chip bus on TG68K`). Summary:

- **Problem:** In CDTV mode every TG68K CPU (68010, 68020, 68020+dcache) black-screens before video, while fx68k boots the same machine/ROMs/disc. From a 2x2 on real HW decoupling `cdtv_mode` from the CD unit: `cdtv_mode` alone is fatal, the CD unit alone is harmless, fx68k with both on boots the disc.
- **Root cause:** `cdtv_bridge` and both `cdtv_nvram` instances take their rd/hwr/lwr strobes from the chip bus out of `minimig_m68k_bridge`. On TG68K, `chipreq` was gated off (`& ~cdtv_selack`) exactly for the CDTV-decoded addresses, so cycles completed from `cdtv_selack` alone — the units saw `sel` with all strobes low. Reads returned unsettled state; writes to DMAC/CR511/NVRAM were dropped, so the extended ROM could never bring the drive up or read its settings.
- **Fix:** Drop `cdtv_selack` from `chipreq` and `clkena_p_base` so CDTV cycles ride the chip bus (like CIAs/RTC/custom regs) and complete on `chip_dtack` with strobes asserted. `cdtv_selack` remains in the `cpu_din` mux — the only path CDTV read data has into the CPU. Also gate `memory_router`'s turbokick window covering `$E00000-$E7FFFF` on `cdtv_mode` (in CDTV mode gary hands that range to the memory card).

Verified:
- Elaboration 0 errors, no new warnings.
- Hardware 2x2 on this branch: `cdtv_mode` fatal alone, CD-unit-alone harmless, fx68k-both-on boots the disc.
