### PR TITLE
cdtv: present read data captured BEFORE the read side effects fire

### DIFF
--- a/rtl/cdtv_bridge.v
+++ b/rtl/cdtv_bridge.v
@@ -310,7 +310,21 @@ wire drain_ack_pop  = drain_ack_u | drain_ack_l;
 wire drain_ack_word = drain_ack_l;
 
 assign selack = sel;
-assign dout   = {rd_byte_eb, rd_byte_ob};
+
+wire rd_active = sel && rd;
+reg  rd_active_d;
+reg [15:0] dout_hold;
+always @(posedge clk) begin
+	if (reset) begin
+		rd_active_d <= 1'b0;
+		dout_hold   <= 16'h0000;
+	end else begin
+		rd_active_d <= rd_active;
+		if (rd_active && !rd_active_d) dout_hold <= {rd_byte_eb, rd_byte_ob};
+	end
+end
+
+assign dout   = rd_active ? {rd_byte_eb, rd_byte_ob} : dout_hold;
 
 always @(posedge clk) begin
 	if (reset) begin


### PR DESCRIPTION
Follow-up to #224 (chip-bus routing). Targets the CD32/CDTV + 68010/68020 combination.

Full narrative is in the commit message. Summary:

- **Problem:** with #224 applied, CDTV register reads on TG68K (68010, 68020) still misbehave: AIR returns 0x00 instead of the interrupt source, ISTR returns flags already cleared, CMDA returns the byte after the one it popped. In practice this means the drive completes two one-byte handshake exchanges and then stops before the first multi-byte reply frame — the disc never finishes loading, even though the chip bus is now live.
- **Root cause:** a ModelSim bench driving `minimig_m68k_bridge` with a TG68K-shaped AS/DS sequence refutes the strobe-loss theory outright — `rd`/`lwr` are exactly 4 `clk_sys` wide with zero lost strobes. The bug is ordering, not presence. Every read side effect in `cdtv_bridge` (reply-FIFO pop, ISTR self-clear, TPI interrupt ack) fires on the falling edge of `rd`, but `dout` was a bare combinational decode of live state. fx68k captures its data on `enPhi2` inside the strobe window and sees pre-side-effect state. TG68K's only clkena for this access is `chipready`, asserted a full `ph1n` period after the cycle terminates, so it samples several clocks after the falling edge and sees post-side-effect state instead.
- **Fix:** `dout` now holds the value sampled at the first clock of the read window and presents it for the whole cycle. Inside the window the live decode passes through unchanged, so fx68k (the only previously-working configuration) is bit-identical to before; only what's presented after the strobe drops changes, which is exactly the window TG68K samples in.

Verified:
- Elaboration and full compile, 0 errors, no new warnings, positive setup/hold slack on every constrained clock.
- Hardware ship gate: alive 8/8 on the 68020 with ext ROM v2.35 (56 colours, 4/5 distinct frames, deterministic rep-to-rep), and 5/5 on the 68010 with ext ROM v1.0 (independently rules out the CPU-speed/turbochip family of explanations, since the 68010 arm has `cpucfg[1]=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)