### PR TITLE
cdtv: carry the full 32-bit DMA address (Z3 fast RAM aliases onto the vector table)

### DIFF
--- a/Minimig.sv
+++ b/Minimig.sv
@@ -335,7 +335,7 @@ wire  [9:0] cdtv_cdda_volume;
 wire        cdtv_cdda_volume_valid;
 wire        cdtv_dma_req;
 wire        cdtv_dma_we;
-wire [23:0] cdtv_dma_baddr;
+wire [31:0] cdtv_dma_baddr;
 wire  [7:0] cdtv_dma_wbyte;
 wire        cdtv_dma_ack;
 

--- a/rtl/cdtv_bridge.v
+++ b/rtl/cdtv_bridge.v
@@ -63,7 +63,7 @@ module cdtv_bridge
 
 	output            cdtv_dma_req,
 	output            cdtv_dma_we,
-	output     [23:0] cdtv_dma_baddr,
+	output     [31:0] cdtv_dma_baddr,
 	output      [7:0] cdtv_dma_wbyte,
 	input             cdtv_dma_ack
 );
@@ -94,7 +94,7 @@ localparam [2:0] DRAIN_PUSH_U = 3'd2;
 localparam [2:0] DRAIN_WAIT_L = 3'd3;
 localparam [2:0] DRAIN_PUSH_L = 3'd4;
 reg [2:0]  drain_state;
-reg [23:0] drain_baddr;
+reg [31:0] drain_baddr;
 reg  [7:0] drain_wbyte;
 reg        drain_req_r;
 
@@ -426,7 +426,7 @@ always @(posedge clk) begin
 	if (reset) begin
 		drain_state <= DRAIN_IDLE;
 		drain_req_r <= 1'b0;
-		drain_baddr <= 24'h0;
+		drain_baddr <= 32'h0;
 		drain_wbyte <= 8'h00;
 	end else begin
 		if (!dmac_dma || prst_pulse) begin
@@ -444,7 +444,7 @@ always @(posedge clk) begin
 					drain_state <= DRAIN_PUSH_U;
 				end
 				DRAIN_PUSH_U: begin
-					drain_baddr <= acr[23:0];
+					drain_baddr <= acr;
 					drain_wbyte <= sec_fifo_q;
 					drain_req_r <= 1'b1;
 					if (cdtv_dma_ack) begin
@@ -456,7 +456,7 @@ always @(posedge clk) begin
 					drain_state <= DRAIN_PUSH_L;
 				end
 				DRAIN_PUSH_L: begin
-					drain_baddr <= acr[23:0] + 24'd1;
+					drain_baddr <= acr + 32'd1;
 					drain_wbyte <= sec_fifo_q;
 					drain_req_r <= 1'b1;
 					if (cdtv_dma_ack) begin

--- a/rtl/chipdma_arb.v
+++ b/rtl/chipdma_arb.v
@@ -23,7 +23,7 @@ module chipdma_arb
 
 	input             cdtv_dma_req,
 	input             cdtv_dma_we,
-	input      [23:0] cdtv_dma_baddr,
+	input      [31:0] cdtv_dma_baddr,
 	input       [7:0] cdtv_dma_wbyte,
 	output      [7:0] cdtv_dma_rbyte,
 	output            cdtv_dma_ack,
@@ -125,7 +125,7 @@ wire any_req       = akiko_dma_req_q | cdtv_dma_req_q;
 wire arming_is_cdtv = ~akiko_dma_req_q & cdtv_dma_req_q;
 
 wire        live_we     = arming_is_cdtv ? cdtv_dma_we    : akiko_dma_we;
-wire [23:0] live_baddr  = arming_is_cdtv ? cdtv_dma_baddr : akiko_dma_baddr;
+wire [31:0] live_baddr  = arming_is_cdtv ? cdtv_dma_baddr : {8'h00, akiko_dma_baddr};
 wire  [7:0] live_wbyte  = arming_is_cdtv ? cdtv_dma_wbyte : akiko_dma_wbyte;
 
 wire arm_now = (state == S_IDLE) & c_7m_rise & minimig_idle & any_req;
@@ -147,7 +147,7 @@ wire        router_zram_sel = |router_ramaddr[28:26];
 
 memory_router u_router
 (
-	.cpu_addr      ({8'h00, live_baddr}),
+	.cpu_addr      (live_baddr),
 	.cchip         (1'b0),
 	.ckick         (1'b0),
 	.wr            (1'b0),
@@ -163,7 +163,11 @@ memory_router u_router
 
 wire    is_ddr_now   = arm_now ? router_zram_sel : ak_is_ddr;
 
-wire arb_drive_chip  = arb_drive & ~is_ddr_now;
+wire        addr_unmapped   = |live_baddr[31:24] & ~router_zram_sel;
+reg         ak_unmapped;
+wire        is_unmapped_now = arm_now ? addr_unmapped : ak_unmapped;
+
+wire arb_drive_chip  = arb_drive & ~is_ddr_now & ~is_unmapped_now;
 
 assign chip_out_addr = arb_drive_chip ? ak_addr_w    : chip_in_addr;
 assign chip_out_l    = arb_drive_chip ? ak_l_w       : chip_in_l;
@@ -188,6 +192,7 @@ always @(posedge clk) begin
 		ak_rbyte_r     <= 8'h00;
 		active_is_cdtv <= 1'b0;
 		ak_is_ddr      <= 1'b0;
+		ak_unmapped    <= 1'b0;
 		dma_ddr_cs_r   <= 1'b0;
 		dma_ddr_we_r   <= 1'b1;
 	end else begin
@@ -205,6 +210,7 @@ always @(posedge clk) begin
 				ak_we          <= live_we;
 				ak_baddr0      <= live_baddr[0];
 				ak_is_ddr      <= router_zram_sel;
+				ak_unmapped    <= addr_unmapped;
 				slot_cnt       <= 3'd0;
 				active_is_cdtv <= arming_is_cdtv;
 				if (router_zram_sel) begin

--- a/rtl/minimig.v
+++ b/rtl/minimig.v
@@ -276,7 +276,7 @@ module minimig
 
 	output        cdtv_dma_req,
 	output        cdtv_dma_we,
-	output [23:0] cdtv_dma_baddr,
+	output [31:0] cdtv_dma_baddr,
 	output  [7:0] cdtv_dma_wbyte,
 	input         cdtv_dma_ack,
 

--- a/rtl/sim/akiko/tb_akiko_chipram_master.sv
+++ b/rtl/sim/akiko/tb_akiko_chipram_master.sv
@@ -66,7 +66,7 @@ chipdma_arb u_dut (
 
 	.cdtv_dma_req    (1'b0            ),
 	.cdtv_dma_we     (1'b0            ),
-	.cdtv_dma_baddr  (24'h000000      ),
+	.cdtv_dma_baddr  (32'h00000000    ),
 	.cdtv_dma_wbyte  (8'h00           ),
 	.cdtv_dma_rbyte  (                ),
 	.cdtv_dma_ack    (                ),

--- a/rtl/sim/cdtv/tb_cdtv_cr511.sv
+++ b/rtl/sim/cdtv/tb_cdtv_cr511.sv
@@ -51,7 +51,7 @@ module tb_cdtv_cr511;
 
 	wire         cdtv_dma_req;
 	wire         cdtv_dma_we;
-	wire  [23:0] cdtv_dma_baddr;
+	wire  [31:0] cdtv_dma_baddr;
 	wire   [7:0] cdtv_dma_wbyte;
 
 	cdtv_bridge u_dut (


### PR DESCRIPTION
Draft. Two commits on top of `cd32_cdtv` @ `920f78c`.

## The bug

The CDTV DMAC address counter register (`acr`) is 32 bits wide and `cdtv_bridge`
latches all four bytes of it, but the path from there to the memory router was
24 bits. The top byte was discarded twice over:

- `rtl/cdtv_bridge.v` -- the drain FSM stored `acr[23:0]`, and `cdtv_dma_baddr`
  was declared `[23:0]`.
- `rtl/chipdma_arb.v` -- `memory_router` was handed `{8'h00, live_baddr}`, so
  even a full-width input would have been re-zeroed.

That is invisible while `cdtv.device`'s sector buffer lives in chip RAM or in
Zorro II fast RAM, because those addresses fit in 24 bits. It is fatal with
Zorro III fast RAM: AmigaOS assigns the Z3 board at `$40000000`, so a buffer
there truncates to `$000000xx` -- directly onto the 68000 exception vector table,
ExecBase at `$4` included. The first sector read writes CD data over low memory
and the machine reset-loops behind the CDTV splash.

It fails silently because nothing catches the bad address. Neither CPU core has
`berr`/`BERRn` wired to anything meaningful, and the chip-bus bridge DTACKs
unconditionally regardless of whether the address is claimed, so the truncated
access simply lands on chip RAM and completes.

`cdtv.device` reaches this with `MEMF_ANY`, so the exposure is not specific to
one ROM: v1.0 (cdtv.device 35.9, alloc at `$F04C78`) and the AmigaOS 3.2 CDTV
extended ROM (35.12, `$F04088`) both take it. The CDTV-Land 2.35 rebuild escapes
only because its 35.15 forces `MEMF_CHIP` at the same call site.

## The fix

Widen `cdtv_dma_baddr` to 32 bits end to end (`cdtv_bridge.v` ->
`chipdma_arb.v` -> `minimig.v` -> `Minimig.sv`) so a Z3 target is routed to DDR
the same way a Z2 target already is.

Then add the guard that arguably should have been there regardless: in
`chipdma_arb`, a DMA address the router does not claim
(`|live_baddr[31:24] & ~router_zram_sel`) no longer falls through to the chip
bus, where the top eight bits do not exist and the access would alias onto low
chip RAM. Such a cycle now completes its handshake driving nothing. This also
covers the case where a 68000 `RESET` has cleared `z3ram_ena` while the OS still
believes the board is configured.

Chip-RAM DMA is bit-for-bit unaffected: its top byte is already zero, so the
guard never fires and the router decision is unchanged. The Akiko leg is
explicitly zero-extended (`{8'h00, akiko_dma_baddr}`) and so is likewise
unchanged.

The second commit widens the two simulation benches that carry this net, so the
ModelSim testbenches exercise the widened path rather than silently truncating
the very bits the fix carries.

## Verification

All hardware testing was done on this fork's DE10-Nano rig, but on a build of
this branch specifically, not of the fork branch the work was developed on.
Worth noting: the tree these commits were developed on is byte-identical to
`cd32_cdtv` @ `920f78c` (same tree hash), so no adaptation was needed beyond
dropping a three-line source comment to match the branch's comment-free style.
Quartus 17.0.2 Lite then produced a bitstream from this branch that is md5
identical to the one the original testing ran on.

Repro matrix, CDTV chipset, 68020, real CD media, AmigaOS 3.2 CDTV extended ROM
(cdtv.device 35.12), scored on per-frame image hashes of timed screen captures:

- Before the fix, the Z3 arm cycles a small set of splash frames indefinitely
  (`85a2142e` / `1b234af1` alternating) -- the reset loop.
- On this branch's build, the same Z3 arm walks the same frame sequence as the
  no-fast-RAM control arm, hash for hash at each settle point (`0f0e81da`,
  `2046c6db`, ...), i.e. it boots and loads the disc.
- The no-fast-RAM and Zorro II control arms are unchanged before and after.

The CDTV ship-gate regression was run against a bitstream md5-identical to
this branch's: 8 boots each
across three arms (68020 + ext ROM v1.0, 68020 + CDTV-Land 2.35, 68010 + ext ROM
v1.0), 24/24 clean.

Quartus 17.0.2 Lite on this branch: clean analysis & elaboration, clean full
compile, 0 errors, timing closed (worst setup slack +0.065 ns).

Not verified: CD32/Akiko mode is untouched by this change on paper (its DMA leg
is explicitly zero-extended and its addresses are chip-RAM addresses, so the new
guard cannot fire) but was not separately re-run for this branch.
