### PR TITLE
Akiko: PIO command register, and DRIVEXMIT for zero-result commands

### DIFF
--- a/rtl/akiko.v
+++ b/rtl/akiko.v
@@ -694,7 +694,8 @@ if (NATIVE_CD32) begin : g_cd
 			if (hps_result_done && (cdrom_receive_length == 6'd0)) begin
 				cdrom_receive_length <= hps_result_wr_ptr;
 				hps_result_wr_ptr    <= 6'd0;
-				cdrom_intreq         <= cdrom_intreq | CDINT_DRIVERECV;
+				if (hps_result_wr_ptr != 6'd0)
+					cdrom_intreq <= cdrom_intreq | CDINT_DRIVERECV;
 			end
 		end
 	end

--- a/rtl/akiko.v
+++ b/rtl/akiko.v
@@ -166,6 +166,8 @@ if (NATIVE_CD32) begin : g_cd
 	reg        tx_busy;
 	reg        rx_busy;
 	reg        rx_inflight;
+	reg        pio_wr_d;
+	reg        pio_rd_d;
 
 	localparam [1:0] OWN_RX = 2'd0, OWN_PBX = 2'd1, OWN_TX = 2'd2, OWN_SUB = 2'd3;
 	reg        dma_owned;
@@ -257,6 +259,23 @@ if (NATIVE_CD32) begin : g_cd
 	                  && (cdcomrxinx != cdcomrxcmp)
 	                  && (rx_dma_delay == 2'd0);
 
+	wire       pio_tx_allowed  = !cdrom_flags[CDFLAG_TXD_BIT] && !tx_busy;
+	wire       pio_tx_can_send = (cdrom_receive_length == 6'd0)
+	                          && (cdrom_command_length != 6'd32)
+	                          && !cmd_pending;
+	wire [3:0] pio_tx_op       = (cdrom_command_length == 6'd0) ? din[11:8] : cmd_op;
+	wire [5:0] pio_tx_next_len = cdrom_command_length + 6'd1;
+	wire       pio_tx_more     = (pio_tx_next_len < expected_total_len(pio_tx_op))
+	                          && (pio_tx_next_len != 6'd32);
+
+	wire       pio_rx_allowed  = !cdrom_flags[CDFLAG_RXD_BIT] && !rx_busy;
+	wire       pio_rx_avail    = pio_rx_allowed
+	                          && (cdrom_receive_offset < cdrom_receive_length);
+	wire [7:0] pio_rx_data     = pio_rx_avail
+	                          ? cdrom_result_buffer[cdrom_receive_offset]
+	                          : pio_byte;
+	wire       pio_rx_last     = (cdrom_receive_offset + 6'd1) == cdrom_receive_length;
+
 	wire pbx_can_start =  (pbx_state == PBX_IDLE)
 	                   && cdrom_flags[CDFLAG_ENABLE_BIT]
 	                   && cdrom_flags[CDFLAG_PBX_BIT]
@@ -306,6 +325,12 @@ if (NATIVE_CD32) begin : g_cd
 	               && !pbx_busy;
 
 	wire write = wr & cs;
+	wire read  = rd & cs;
+
+	wire pio_wr_sel  = write && (addr == 5'b10100) && uds;
+	wire pio_rd_sel  = read  && (addr == 5'b10100);
+	wire pio_wr_edge = pio_wr_sel & ~pio_wr_d;
+	wire pio_rd_edge = pio_rd_sel & ~pio_rd_d;
 
 	wire enable_rising = write && (addr == 5'b10010) && uds && din[10]
 	                  && !cdrom_flags[CDFLAG_ENABLE_BIT];
@@ -330,6 +355,8 @@ if (NATIVE_CD32) begin : g_cd
 			cdcomtxcmp          <= 8'h0;
 			cdcomrxcmp          <= 8'h0;
 			pio_byte            <= 8'h0;
+			pio_wr_d            <= 1'b0;
+			pio_rd_d            <= 1'b0;
 			nvram_io            <= 8'h0;
 			nvram_dir           <= 8'h0;
 			cdrom_command_length <= 6'h0;
@@ -362,6 +389,9 @@ if (NATIVE_CD32) begin : g_cd
 		end else begin
 			if (tx_dma_delay != 2'd0) tx_dma_delay <= tx_dma_delay - 2'd1;
 			if (rx_dma_delay != 2'd0) rx_dma_delay <= rx_dma_delay - 2'd1;
+
+			pio_wr_d <= pio_wr_sel;
+			pio_rd_d <= pio_rd_sel;
 
 			if (dma_arm) begin
 				dma_owned <= rx_busy | pbx_busy | tx_busy | subcode_busy;
@@ -470,9 +500,13 @@ if (NATIVE_CD32) begin : g_cd
 					cdrom_flags <= new_flags;
 				end
 				5'b10100: begin
-					if (uds) begin
-						pio_byte     <= din[15:8];
-						cdrom_intreq <= cdrom_intreq & ~CDINT_DRIVEXMIT;
+					if (pio_wr_edge && pio_tx_allowed) begin
+						cdrom_intreq <= (cdrom_intreq & ~CDINT_DRIVEXMIT)
+						              | ((pio_tx_can_send && pio_tx_more) ? CDINT_DRIVEXMIT : 32'h0);
+						if (pio_tx_can_send) begin
+							cdrom_command_buffer[cdrom_command_length] <= din[15:8];
+							cdrom_command_length <= pio_tx_next_len;
+						end
 					end
 				end
 				5'b11000: begin
@@ -484,6 +518,20 @@ if (NATIVE_CD32) begin : g_cd
 				end
 				default: ;
 			endcase
+			end
+
+			if (pio_rd_edge) begin
+				pio_byte <= pio_rx_data;
+				if (pio_rx_avail) begin
+					cdrom_receive_offset <= cdrom_receive_offset + 6'd1;
+					if (pio_rx_last) begin
+						cdrom_receive_length <= 6'd0;
+						cdrom_receive_offset <= 6'd0;
+						cdrom_intreq <= (cdrom_intreq & ~CDINT_DRIVERECV) | CDINT_DRIVEXMIT;
+					end
+				end else begin
+					cdrom_intreq <= cdrom_intreq & ~CDINT_DRIVERECV;
+				end
 			end
 
 			if (tx_busy) begin
@@ -661,7 +709,7 @@ if (NATIVE_CD32) begin : g_cd
 			5'b10000: cd_dout_r = cdrom_pbx;
 			5'b10010: cd_dout_r = cdrom_flags[31:16];
 			5'b10011: cd_dout_r = cdrom_flags[15:0];
-			5'b10100: cd_dout_r = {pio_byte, 8'h0};
+			5'b10100: cd_dout_r = {pio_rx_data, 8'h0};
 			5'b11000: cd_dout_r = {nvram_scl_bus, nvram_sda_bus, 6'h0, 8'h0};
 			5'b11001: cd_dout_r = {nvram_dir, 8'h0};
 			default:  cd_dout_r = 16'h0;

--- a/rtl/akiko.v
+++ b/rtl/akiko.v
@@ -233,7 +233,13 @@ if (NATIVE_CD32) begin : g_cd
 	endfunction
 
 	wire [3:0] cmd_op       = cdrom_command_buffer[0][3:0];
+	wire [7:0] cmd_arg1     = cdrom_command_buffer[1];
 	wire [5:0] cmd_total    = expected_total_len(cmd_op);
+
+	wire cmd_zero_result = ((cmd_op == 4'h5) && !cmd_arg1[7])
+	                    ||  (cmd_op == 4'h8)
+	                    ||  (cmd_op == 4'h9)
+	                    ||  (cmd_op == 4'ha);
 	wire       cmd_pending  = (cdrom_command_length != 6'd0)
 	                       && ((cdrom_command_length >= cmd_total)
 	                          || (cdrom_command_length == 6'd32));
@@ -677,6 +683,9 @@ if (NATIVE_CD32) begin : g_cd
 				cdrom_command_length <= 6'd0;
 				hps_cmd_rd_ptr       <= 6'd0;
 			end
+
+			if (hps_cmd_done && cmd_zero_result && !hps_result_done)
+				cdrom_intreq <= cdrom_intreq | CDINT_DRIVEXMIT;
 
 			if (hps_result_push && (hps_result_wr_ptr != 6'd32)) begin
 				cdrom_result_buffer[hps_result_wr_ptr[4:0]] <= hps_result_byte;


### PR DESCRIPTION
Two Akiko accuracy fixes against WinUAE's `akiko.cpp`, both confined to `rtl/akiko.v`. No userspace change, so a stock release binary plus this RTL is enough to reproduce.

**1. PIO command register at `$B80028`.** The register wrote a byte to a holding latch and cleared DRIVEXMIT, but never framed a command or advanced the transmit length, so a loader driving the command channel through PIO rather than DMA could not issue a command at all. Reads now consume from the result buffer and retire DRIVERECV at the last byte.

**2. DRIVEXMIT for a command that returns no result.** WinUAE's dispatcher ends with

```c
if (len == 0) { set_status(CDINTERRUPT_DRIVEXMIT); return; }
```

(`akiko.cpp:1285-1291`). Three commands take that path: LED with bit 7 of the argument clear, which `cdrom_command_led` returns 0 for at `akiko.cpp:922`, and opcodes 8, 9 and 0x0a via the dispatcher's default arm. We implemented the returns-nothing half and not the raise, leaving DRIVEXMIT with only two producers. A guest that issues a zero-result command and then waits for the transmitter before sending its next command byte waits forever, with the machine otherwise idle.

### Hardware test

DE10-Nano, 2021 Jim Power in Mutant Planet CD32 release, both arms in one session on the same disc and launcher.

| | max RGB component | distinct frames | colours |
|---|---|---|---|
| without commit 2 | 17 | 1 of 20 | 11 |
| with commit 2 | 255 | 20 of 20 | 205 |

Without it the disc freezes on the LORICIEL card at a fade held on step 1, identically at 40 s, 80 s and 150 s. With it the disc streams its CDXL intro and reaches the title screen, whether the intro is watched or skipped.

### Scope and caveats

- Commit 1 was tested alone and did **not** move the hang. The two have only been run stacked, so commit 2 is unverified in isolation.
- Not fixed here: the `result_done` arm still raises DRIVERECV when `hps_result_wr_ptr` is zero, announcing a result that does not exist, where WinUAE does not call `cdrom_start_return_data` at all. It is unreachable with the current bridge and would make this a three-change branch.
- Both changes sit inside `if (NATIVE_CD32)`, so non-CD32 configurations are unaffected.

Draft while the DRIVERECV item and a clean-tree re-fit are settled.
