### PR TITLE
agnus: advance the DMA slot grid one colour clock, and move STRHOR with it

### DIFF
--- a/rtl/agnus.v
+++ b/rtl/agnus.v
@@ -268,7 +268,7 @@ wire  dma_ref;        //refresh dma slots
 
 agnus_refresh ref1
 (
-	.hpos(hpos),
+	.hpos(hpos_slot),
 	.dma(dma_ref)
 );
 
@@ -286,7 +286,7 @@ agnus_diskdma dsk1
 	.dmal(disk_dmal),
 	.dmas(disk_dmas),
 	.speed(floppy_speed),
-	.hpos(hpos),
+	.hpos(hpos_slot),
 	.wr(wr_dsk),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_dsk),
@@ -308,7 +308,7 @@ agnus_audiodma aud1
 	.dma(dma_aud),
 	.audio_dmal(audio_dmal),
 	.audio_dmas(audio_dmas),
-	.hpos(hpos),
+	.hpos(hpos_slot),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_aud),
 	.data_in(data_in),
@@ -335,6 +335,7 @@ agnus_bitplanedma bpd1
 	.dmaena(bplen),
 	.vpos(vpos),
 	.hpos(hpos),
+	.hpos_slot(hpos_slot),
 	.hde(hde),
 	.dma(dma_bpl),
 	.reg_address_in(reg_address),
@@ -359,7 +360,7 @@ agnus_spritedma spr1
 	.ecs(ecs),
 	.reqdma(req_spr),
 	.ackdma(ack_spr),
-	.hpos(hpos),
+	.hpos(hpos_slot),
 	.vpos(vpos),
 	.vbl(vbl),
 	.vblend(vblend),
@@ -389,6 +390,7 @@ agnus_copper cp1
 	.blit_busy(blit_busy),
 	.vpos(vpos[7:0]),
 	.hpos(hpos),
+	.hpos_slot(hpos_slot),
 	.data_in(data_in),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_cop),
@@ -438,6 +440,8 @@ agnus_blitter bl1
 //--------------------------------------------------------------------------------------
 
 wire  [8:0] hpos;      //alternative horizontal beam counter
+wire  [7:0] hpos_slot_hi = (hpos[8:1] == htotal[8:1]) ? 8'd0 : hpos[8:1] + 8'd1;
+wire  [8:0] hpos_slot = {hpos_slot_hi, hpos[0]};
 wire [10:0] vpos;      //vertical beam counter
 wire        vbl;       //JB: vertical blanking
 wire        vblend;    //JB: last line of vertical blanking
@@ -479,7 +483,7 @@ agnus_beamcounter  bc1
 //horizontal strobe for Denise
 //in real Amiga Denise's hpos counter seems to be advanced by 4 CCKs in regards to Agnus' one
 //Minimig isn't cycle exact and compensation for different data delay in implemented Denise's video pipeline is required
-assign strhor_denise = hpos==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
+assign strhor_denise = hpos_slot==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
 assign strhor_paula = hpos==(6*2+1) ? 1'b1 : 1'b0; //hack
 
 //--------------------------------------------------------------------------------------

--- a/rtl/agnus_bitplanedma.v
+++ b/rtl/agnus_bitplanedma.v
@@ -38,6 +38,7 @@ module agnus_bitplanedma (
   input  wire           dmaena,           // enable dma input
   input  wire [ 11-1:0] vpos,             // vertical position counter
   input  wire [  9-1:0] hpos,             // agnus internal horizontal position counter (advanced by 4 CCK)
+  input  wire [  9-1:0] hpos_slot,        // dma slot grid index
   output reg            hde,              // video data enable (horizontal)
   output wire           dma,              // true if bitplane dma engine uses it's cycle
   input  wire [  9-1:1] reg_address_in,   // register address inputs
@@ -316,7 +317,7 @@ assign bp_fmode3  = (fmode[1:0] == 2'b11);
 // bitplane dma enable bit delayed by 4 CCKs
 always @ (posedge clk) begin
   if (clk7_en) begin
-    if (hpos[1:0]==2'b11)
+    if (hpos_slot[1:0]==2'b11)
       dmaena_delayed[1:0] <= #1 {dmaena_delayed[0], dmaena};
   end
 end
@@ -336,7 +337,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
+      if (hpos_slot[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
         soft_start <= #1 1'b1;
       else
         soft_start <= #1 1'b0;
@@ -346,7 +347,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
+      if (hpos_slot[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
         soft_stop <= #1 1'b1;
       else
         soft_stop <= #1 1'b0;
@@ -356,7 +357,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos[8:1]==8'h18)
+      if (hpos_slot[8:1]==8'h18)
         hard_start <= #1 1'b1;
       else
         hard_start <= #1 1'b0;
@@ -366,7 +367,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos[8:1]==8'hD8)
+      if (hpos_slot[8:1]==8'hD8)
         hard_stop <= #1 1'b1;
       else
         hard_stop <= #1 1'b0;
@@ -422,7 +423,7 @@ assign ddfseq_match = ((!hires && !shres && bp_fmode3)                          
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0]) //cycle alligment
-      if (ddfena && vdiwena && !hpos[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
+      if (ddfena && vdiwena && !hpos_slot[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
         ddfrun <= #1 1'b1;
       else if ((ddfend || !vdiwena) && ddfseq_match) // cleared at the end of last bitplane DMA cycle
         ddfrun <= #1 1'b0;

--- a/rtl/agnus_copper.v
+++ b/rtl/agnus_copper.v
@@ -68,6 +68,7 @@ module agnus_copper
 	input	blit_busy,					// blitter busy flag input
 	input	[7:0] vpos,					// vertical beam counter
 	input	[8:0] hpos,					// horizontal beam counter
+	input	[8:0] hpos_slot,			// dma slot grid index
 	input 	[15:0] data_in,	    		// data bus input
 	input 	[8:1] reg_address_in,		// register address input
 	output 	reg [8:1] reg_address_out,	// register address output
@@ -342,7 +343,7 @@ such a behaviour is caused by dma request pipelining in real Agnus
 always @(posedge clk)
   if (clk7_en) begin
   	if (clk_ena)
-  		if (hpos[8:1]==8'h01)
+  		if (hpos_slot[8:1]==8'h01)
   			bus_blk <= 1; //cycle $E1 is blocked
   		else
   			bus_blk <= 0;


### PR DESCRIPTION
Fixes the one-pixel vertical jitter on Hybris's cannon/turret sprite by moving the DMA slot grid one colour clock earlier, and moving Denise's STRHOR strobe with it.

*Updated after review feedback: the submodule ports keep their original `hpos` name, so the patch is now 3 files / +18 −12 instead of 7 files / +53 −47, and every remaining line is a real change rather than a rename. Logic is unchanged from the build that was tested on hardware.*

### Why this is a bug and not authenticity

A real Amiga 500 does not jitter here. Neither does WinUAE, nor Copperline, configured as an A500. WinUAE places its first RGA refresh cycle at H=3 (`REFRESH_FIRST_HPOS`, `custom.cpp`); ours lands at 4.

### What was measured

The grid advance was A/B'd on real hardware on a **single bitstream** through a live debug knob, with no core reload between arms, so the two arms differ in exactly one wire:

| Arm | Turret excursions | Settled frames |
|---|---|---|
| Grid as shipped | 11 | 148 |
| Grid advanced 1 CCK | 0 | 165 |

Fisher exact, two-sided: **p = 2.156e-4**.

The completed change was then rebuilt on this base and confirmed on a MiSTer by eye: turret steady, horizontal scrolling smooth, HUD shadow sprites present.

### Shape of the patch

`refresh`, `diskdma`, `audiodma` and `spritedma` only ever look at the slot grid, so they are simply handed `hpos_slot` on their existing `hpos` port and are **untouched**. Only the two modules that genuinely need both counters gain a second input:

- **`agnus_bitplanedma`** — the DDF window (DDFSTRT, DDFSTOP, the `$18`/`$D8` hard limits), the DMAENA delay and the odd-timeslot test move; `hde` stays on the raw counter.
- **`agnus_copper`** — only the `$E1` blocked cycle moves.

### Two details worth flagging for review

**`hpos_slot` advances `hpos[8:1]` and preserves `hpos[0]`.** `hpos[0]` *is* the colour-clock phase (`agnus_beamcounter.v` drives it from `always @(cck)`). Writing `hpos + 1` advances half a colour clock and does so silently — it elaborates, fits and boots.

**STRHOR has to move too, and that is most of the risk retired here.** Denise is not cycle exact; it keeps its own horizontal counter reset by `strhor` (`denise.v:100-107`) and has no `hde` port at all (`minimig.v:654-677`), so its entire horizontal phase is defined by that strobe. An earlier build advanced the grid but left `strhor_denise` on the raw counter, and it regressed on hardware — jagged scrolling in every horizontally scrolling title, and lost shadow sprites in Hybris's HUD. `denise_bitplanes.v:83-90` selects `extra_delay_f0` from `hpos[3:2]` at the BPL1DAT write and uses it to pick the modulo-16 shifter tap, so advancing the fetch without advancing Denise's counter lands the write in a different four-CCK bucket and the BPLCON1 fine scroll stops composing with the coarse word fetch. Both symptoms are gone with STRHOR on the slot grid.

### Scope

The grid moves as one. A partial application would be worse than no change: at bpu=5 lores, mixing shifted and unshifted channels widens the occupied-slot union from five of eight to six, dropping free slots from three to two — roughly 40% of CPU bandwidth on every five-bitplane lores title.

`hde` and `strhor_paula` are deliberately left on the raw counter. `hde` only feeds the optional external-blanking path (`minimig.v:433`); `strhor_paula` is an existing hack and out of scope.

### Build

Timing closes with all slacks positive, worst setup **+0.235 ns**. Based on `c26772a`, so it sits on top of the merged #229 and #230.

Draft: broad fleet regression across many titles has not been run yet. Filing so the reasoning and the hardware evidence can be reviewed while that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUb4ipv1AvEXxtF9gs6dAf
