### PR TITLE
minimig: stock-speed throttle runs at half A1200 speed, not A1200 speed

### DIFF
--- a/rtl/cpu_wrapper.v
+++ b/rtl/cpu_wrapper.v
@@ -312,7 +312,7 @@ reg [3:0] cooldown;
 always @(posedge clk) begin
 	if (~reset)                                cooldown <= 4'd0;
 	else if (cooldown != 4'd0)                 cooldown <= cooldown - 4'd1;
-	else if (stock_speed & clkena_p_base)      cooldown <= 4'd9;
+	else if (stock_speed & clkena_p_base)      cooldown <= 4'd4;
 end
 wire clkena_p_throttled = clkena_p_base & (cooldown == 4'd0);
 


### PR DESCRIPTION
The 020 stock-speed throttle already in mainline divides the pipeline rate by **ten**, not by five, so a user who enables it gets a machine running at roughly **half** the speed of the A1200 it is imitating. One constant.

```diff
-	else if (stock_speed & clkena_p_base)      cooldown <= 4'd9;
+	else if (stock_speed & clkena_p_base)      cooldown <= 4'd4;
```

`cooldown <= k` yields one `clkena` per `k+1` cycles, so `4'd9` is a divide by ten. The unthrottled 020 is about 4.8x faster than a stock A1200, not 10x.

### Measurements

Real DE10-Nano, Copperline `timing-test.adf`, scoring the CPU-only rows (`move`, `shift`, `mul`, `dbra`, `dbraChip`) as a ratio of real-A1200 wall time. Silicon reference is a stock A1200 (68EC020 @ 14.19 MHz, AGA, 2 MB chip, KS 3.2.3).

| arm | cpu-only rows vs real A1200 |
|---|---|
| throttle off | 0.209x (4.78x too fast) |
| `4'd9`, divide 10 — what mainline ships | **2.081x** (half A1200 speed) |
| `4'd4`, divide 5 — this patch | **1.041x** |

The divide-10 / divide-5 ratio comes back at **2.000 on every CPU-only row**, worst deviation 0.08%, so the mechanism is linear and the constant is the whole error.

### The throttle stays out of the chipset

It paces the CPU pipeline only. Rows that are chipset-paced do not move when it is enabled — this was registered as the discriminator before the runs:

| row | ON/OFF |
|---|---|
| 8 `frame` | 1.00014 |
| 23 `blitClr` | 0.99842 |
| 26 `fill+3bpl` | 1.00191 |
| 27 `copperPoll` | 1.00020 |

Worst deviation 0.0019 against a pre-registered band of 0.02.

### Verified end to end, not just as a forced wire

The final run used **one bitstream and two configs differing in a single bit** — CPU config bit 5 — so the enable path is exercised for real: CFG byte → `minimig_ConfigCPU` → `UIO_MM2_CPU` → `t_cpu_config[5]` → `cachecfg[3]` → `cooldown`. CPU-only rows came back at **4.979x** ON/OFF (predicted 5.000). Screen decode residual 0.00/row on both arms, all four sentinels zero.

### What this is not

Divide-5 is the best available setting, not an exact match, and it is worth saying so rather than letting someone discover it:

- **Per-instruction error against silicon spans +11.1% (`move`) to -9.1% (`shift`)**, because the core is not a 68EC020 and its instruction cycle counts differ. A scalar divisor can centre that spread; it cannot close it.
- **A fractional divisor would make it worse.** Exact would be divide-4.785. Trimming the residual 4% scales every row by 0.961, which gives `move` +6.7% and `shift` **-12.7%** — mean absolute error improves 8.6% → 6.3%, but the worst row crosses 12%. Rejected on measurement, not on effort.
- **Only the pipeline is held**, so loops that interleave CPU work with chip access are not slowed the way silicon slows them (about +50% → +120…+160% vs real). Correct average CPU rate, no bus model.

### Note on reachability

The enable bit is currently inert from a stock userspace binary: `Main_MiSTer` masks the CPU config byte with `0x1f` in `minimig_ConfigCPU`, dropping bit 5 before it is sent, and no menu row sets it. That is a separate Main_MiSTer change and is filed alongside this one. This patch makes the constant correct for when it lands; on its own it changes no observable behaviour.

These two need to land together: on its own this patch changes no observable behaviour, and the userspace patch on its own would enable a divide-by-ten.

Companion userspace PR: MiSTer-devel/Main_MiSTer#1296


