### PR TITLE
agnus: VHPOSR reads one colour clock high

### DIFF
--- a/rtl/agnus_beamcounter.v
+++ b/rtl/agnus_beamcounter.v
@@ -106,7 +106,7 @@ always @(*) begin
 	if (reg_address_in[8:1]==VPOSR[8:1] || reg_address_in[8:1]==VPOSW[8:1])
 		data_out[15:0] = {long_frame,1'b0,ecs,ntsc,2'b00,{2{aga}},long_line,4'b0000,vpos[10:8]};
 	else if (reg_address_in[8:1]==VHPOSR[8:1] || reg_address_in[8:1]==VHPOSW[8:1])
-		data_out[15:0] = {vpos[7:0],hpos[8:1]};
+		data_out[15:0] = {vpos[7:0],|hpos[8:1] ? hpos[8:1] - 8'd1 : ersy ? 8'd0 : htotal[8:1]};
 	else
 		data_out[15:0] = 0;
 end


### PR DESCRIPTION
The VHPOSR readback returns the internal `hpos`, which runs one colour clock ahead of the value real Agnus reports. Every horizontal beam probe in the vAmigaTS VPOS suite reads +1, and the row that should report the htotal wrap reads `0` instead.

The decrement is applied in the combinational readback only. `data_out` is assigned in an `always @(*)` block and cannot affect beam position; `hpos[8:1]` is assigned on `posedge clk` and can. An earlier attempt that moved the ERSY park instead regressed the `ersy2` case, which was already correct — hence the deliberately narrow edit here.

`hpos[8:1]` reaches zero with two distinct meanings that need different answers. Free-running, zero is the wrap and must read `htotal`; held by an ERSY genlock freeze, zero must read zero. `BPLCON0[1]` discriminates them, so the wrap case is gated on `~ersy`. That the discriminator is correct was checked against the suite's own sources: `ersy2.s:89` sets `$2202` and `:125` clears it with all sixteen samples in between, while `probe5.s:43` is `$2200`.

## Measured on hardware

vAmigaTS VPOS suite, A500 ECS PAL, 19 tests, three frames each. Values are decoded from the hex the probes print on screen, so these are the guest-visible register reads, not a simulation.

| | before | after |
|---|---|---|
| probe rows at 0 | 76 of 304 | **268 of 304** |
| rows at +1 | 191 | 0 |
| rows at -226 | 1 | 0 |

| test | result |
|---|---|
| `ersy2` | `4000` on rows 4-15, matches the reference exactly |
| `ersy1` | 0 on 14 of 16 rows |
| `probe5` | row 4 reads `FFE2`, the htotal wrap, matches the reference |
| `probe2`-`probe9`, `vprobe1`-`vprobe4` | 0 on every row |

## What this does not fix

The 36 rows that still differ all belong to the copper-WAIT probes (`probe1`, `probe10`, `probe13`, `ersy1`) and carry a second, independent error of -4 in the body and -11 at the transition. That error was being partly cancelled by the +1 above, so those rows shift by one here. It is not a regression, and this change makes no claim about it.

`VHPOSW` is untested. `vhpos1`-`vhpos5` render an all-red reference and cannot be scored in either direction.

## Provenance of the bitstream

The hardware evidence above was gathered on a bitstream built from `b265a3b` plus this one line (fit: setup -0.057, hold +0.247, TNS 0). The branch is rebased onto current `MiSTer`; mainline's only change to this file since then is `d16cd84` at line 345, unrelated to the readback, so the rebase is textual — but the rebased tree has not itself been fitted or booted yet. Draft until it is.
