### PR TITLE
gary: decode the custom registers at $DFxxxx, not across all of $C0-$DF

### DIFF
--- a/rtl/gary.v
+++ b/rtl/gary.v
@@ -189,7 +189,7 @@ assign t_sel_slow[2] = (cpu_address_in[23:19]==5'b1101_0) && &memory_config[3:2]
 assign sel_ide   = hdc_ena && cpu_address_in[23:16]==8'b1101_1010;        //IDE registers at $DA0000 - $DAFFFF	
 assign sel_gayle = hdc_ena && cpu_address_in[23:12]==12'b1101_1110_0001;  //GAYLE registers at $DE1000 - $DE1FFF
 assign sel_rtc   = cpu_address_in[23:16]==8'b1101_1100;                   //RTC registers at $DC0000 - $DCFFFF
-assign sel_reg   = cpu_address_in[23:21]==3'b110 ? ~(|t_sel_slow | sel_rtc | sel_ide | sel_gayle) : 1'b0;	//chip registers at $DF0000 - $DFFFFF
+assign sel_reg   = cpu_address_in[23:16]==8'b1101_1111;                   //chip registers at $DF0000 - $DFFFFF
 assign sel_cia   = cpu_address_in[23:16]==8'hBF; // $BFxxxx
 assign sel_cia_a = sel_cia & ~cpu_address_in[12];
 assign sel_cia_b = sel_cia & ~cpu_address_in[13];


### PR DESCRIPTION
`sel_reg` selects the custom register bank for the whole 2 MB `$C00000..$DFFFFF` window, not the `$DF0000..$DFFFFF` its own comment claims.

`rtl/gary.v:192`

```verilog
assign sel_reg = cpu_address_in[23:21]==3'b110 ? ~(|t_sel_slow | sel_rtc | sel_ide | sel_gayle) : 1'b0;  //chip registers at $DF0000 - $DFFFFF
```

`addr[23:21]==3'b110` is `$C00000..$DFFFFF`. Subtracting slow RAM, RTC, IDE and Gayle still leaves `$D80000`, `$DB0000`, `$DD0000`, `$DE0000`, `$DE2000..$DEFFFF` — and `$C00000..$D7FFFF` too, whenever the configured slow RAM does not reach that far. `reg_address` is `[8:1]` (`minimig.v:352`), so an access anywhere in those holes lands on a real custom register chosen by address bits 8:1 alone.

Line 207 in the same file already decodes the range correctly for `dbs`:

```verilog
assign dbs = ... || cpu_address_in[23:16]==8'b1101_1111;
```

so the two lines disagree with each other about where the registers are. This makes `sel_reg` agree with `dbs` and with its own comment. The four carve-outs are redundant once the test is `$DF` only — slow RAM tops out at `$D7FFFF`, RTC is `$DC`, IDE is `$DA`, Gayle is `$DE1` — so the expression collapses to the single compare.

Tightening it cannot hang the CPU: `_ta_n` in `minimig_m68k_bridge.v:151` acknowledges the cycle without reference to `sel_reg`. A read of a now-unmapped address returns a deterministic `$0000` rather than floating — `cpu_data_in` is the OR-bus at `gary.v:123` — and a write is dropped.

What this could change for existing software: anything relying on the custom registers being reachable through `$C00000..$DEFFFF` now reads `$0000` and writes nowhere. `sel_reg` has exactly one consumer, `.aen()` on Agnus at `minimig.v:509`, and nothing else in the tree reads it, so the blast radius is that window and only that window. The only traffic I have found there is a machine-identification probe that expects *no* device — precisely the case the old decode got wrong.

## How it was found, and how it was confirmed

WhichAmiga 1.4 does not display correctly on Minimig — blank most frames, an occasional garbled frame, never readable text, for the whole session. It probes for an A3000/A4000 DMAC by writing bytes `$7F/$FF/$FD` to `$00DD0080`. Under the old decode that is register offset `$080`, **COP1LCH**. The copper list pointer is destroyed and the display never recovers.

I bisected the actual binary rather than guessing. Each rung overwrites one instruction's first word with `$60FE` (`bra.s *`) — two code bytes, nothing moves, no reloc entry touched — and the run is gated at both ends. All measurements on **stock Release 20260823**, 113–115 captured frames per arm, scored on running-vs-blank fraction.

| rung | adds | running |
|---|---|---|
| t0 (floor gate) | nothing — banner only | 100.0% |
| t4 | GetGfxChip: all-DMA-off, Denise/Lisa ID read at `$DFF07C`, DMA restore | 100.0% |
| t8 | GetCPU/GetFPU — both `SetTaskPri(127)`/`LoadView(NULL)` display blankers | 100.0% |
| t9 | gfx/snd/exp board and chip/fast/virt memory probes | 100.0% |
| u2 | + GetChipRomVer, GetKickStr | 100.0% |
| **v1** | **+ `bsr.w $12bc`, the DMAC probe** | **17.4%** |
| full | unmodified | 17.4% |

One `bsr.w` is the entire difference between 100.0% and 17.4%.

The causal control is the part that matters. Same program, unmodified except the four `lea.l $00DD0080,a3` rewritten to `lea.l $00DD01FE,a3` — eight code bytes, same page, same access type, same decode path, `$1FE` (NO-OP) instead of `$080`:

| image | running | frames |
|---|---|---|
| unmodified | 17.4% | 115 |
| `$DD0080` → `$DD01FE` | **100.0%** | 113 |

If `$00DD0000` were genuinely undecoded, the register offset could not matter.

And with this patch applied, on a fitted bitstream, the **unmodified** binary with nothing patched:

| core | running | frames |
|---|---|---|
| stock Release 20260823 | 17.4% | 115 |
| **this branch** | **100.0%** | **114/114** |

The same guest also reads `$00DD001C` (INTENAR) and writes `$FFFFFFFF` to `$00DD0004` (VPOSW/VHPOSW) through the same hole.

## Timing

The worst setup corner on this design is a PLL output counter (`emu|pll|pll_inst|…|counter[0]|divclk`, the `clk_114` domain) and it is placement-dominated, so I measured that rather than asserting it.

**Paired control — same worktree, same `.qsf`, same seed, only this one line reverted:**

| seed 7 | setup WNS | setup TNS | hold WNS | hold TNS |
|---|---|---|---|---|
| base (`67af318`) | −0.233 | −0.410 | +0.246 | 0.000 |
| this branch | −0.806 | −1.151 | +0.253 | 0.000 |

| seed 1 | setup WNS | setup TNS | hold WNS | hold TNS |
|---|---|---|---|---|
| base (`67af318`) | −0.468 | −0.584 | +0.147 | 0.000 |
| this branch | −0.546 | −0.920 | +0.182 | 0.000 |

The base fails that corner too. The sign is not something this change introduces.

Both pairs put the branch behind the base on setup, by 0.573 and 0.078. I am not
going to read that as "no cost" — the direction is consistent. But the two
margins differ by a factor of seven, and with two pairs I cannot separate a real
sub-nanosecond cost from placement noise whose amplitude on this design is
larger than either figure. If you want that settled rather than bounded, say so
and I will run more pairs.

**Population, for scale.** Across 66 fits of this design sitting on my machine, that corner spans **−2.216 … +0.567** and is negative in **29 of 66**. Two of those trees are unmodified upstream and land on opposite sides: `b265a3b` (Release 20260823) at **+0.248**, `920f78c` at **−0.462**. Re-rolling the seed on this branch alone moved it from −0.546 to −0.806.

Hold is the number that is *not* placement noise here, and it does not degrade: **+0.253 at seed 7 and +0.182 at seed 1, TNS 0.000, 0 failing paths in both**. The base's own seed-1 fit came in at +0.147, so the band across these fits is +0.147 … +0.26 rather than the +0.16 floor I quoted earlier — the branch sits above its paired base on hold in both pairs.

I'd rather show you both numbers than quote whichever seed flattered the patch. If you want a different corner or a specific seed reported, say which.

One file, +1 −1.



