### PR TITLE
agnus: keep bitplane DMA on the raw horizontal counter (fixes #237)

### DIFF
--- a/rtl/agnus.v
+++ b/rtl/agnus.v
@@ -335,7 +335,6 @@ agnus_bitplanedma bpd1
 	.dmaena(bplen),
 	.vpos(vpos),
 	.hpos(hpos),
-	.hpos_slot(hpos_slot),
 	.hde(hde),
 	.dma(dma_bpl),
 	.reg_address_in(reg_address),

--- a/rtl/agnus_bitplanedma.v
+++ b/rtl/agnus_bitplanedma.v
@@ -38,7 +38,6 @@ module agnus_bitplanedma (
   input  wire           dmaena,           // enable dma input
   input  wire [ 11-1:0] vpos,             // vertical position counter
   input  wire [  9-1:0] hpos,             // agnus internal horizontal position counter (advanced by 4 CCK)
-  input  wire [  9-1:0] hpos_slot,        // dma slot grid index
   output reg            hde,              // video data enable (horizontal)
   output wire           dma,              // true if bitplane dma engine uses it's cycle
   input  wire [  9-1:1] reg_address_in,   // register address inputs
@@ -317,7 +316,7 @@ assign bp_fmode3  = (fmode[1:0] == 2'b11);
 // bitplane dma enable bit delayed by 4 CCKs
 always @ (posedge clk) begin
   if (clk7_en) begin
-    if (hpos_slot[1:0]==2'b11)
+    if (hpos[1:0]==2'b11)
       dmaena_delayed[1:0] <= #1 {dmaena_delayed[0], dmaena};
   end
 end
@@ -337,7 +336,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
+      if (hpos[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
         soft_start <= #1 1'b1;
       else
         soft_start <= #1 1'b0;
@@ -347,7 +346,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
+      if (hpos[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
         soft_stop <= #1 1'b1;
       else
         soft_stop <= #1 1'b0;
@@ -357,7 +356,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'h18)
+      if (hpos[8:1]==8'h18)
         hard_start <= #1 1'b1;
       else
         hard_start <= #1 1'b0;
@@ -367,7 +366,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'hD8)
+      if (hpos[8:1]==8'hD8)
         hard_stop <= #1 1'b1;
       else
         hard_stop <= #1 1'b0;
@@ -423,7 +422,7 @@ assign ddfseq_match = ((!hires && !shres && bp_fmode3)                          
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0]) //cycle alligment
-      if (ddfena && vdiwena && !hpos_slot[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
+      if (ddfena && vdiwena && !hpos[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
         ddfrun <= #1 1'b1;
       else if ((ddfend || !vdiwena) && ddfseq_match) // cleared at the end of last bitplane DMA cycle
         ddfrun <= #1 1'b0;


### PR DESCRIPTION
Fixes #237.

This is a regression fix for #232, which I authored. #232 advanced the chipset DMA
slot grid by one colour clock; on hardware that broke The Electronic Knights'
*Rampage*, and — found while validating this — it also clips two pixels off the
left edge of ordinary lores screens. This PR puts back the one module that causes
both, and leaves the rest of #232 in place.

## Symptoms

**1. Rampage fails on A500/OCS.** The picture starts corrupting at **t ≈ 58 s**,
during the chrome RAMPAGE logo build — about 20 s *before* the scene-2 transition
the issue title names — and the demo never advances past the logo. No Guru; it
keeps animating.

**2. A second, unreported regression: #232 clips the picture.** The whole image
sits 2 lo-res px (1 CCK) left of where it belongs, and the leftmost 2 lo-res px of
a **standard `$38` lores screen fall off the left edge**. This affects ordinary
titles, not just Rampage. It was found only because the horizontal-scroll probe was
promoted to a primary measurement while choosing between candidate fixes.

Two independent instruments agree on it: DDF phase bands at `$38`/`$3a` measure
18 px wide instead of 20, and the sprite-multiplex probe counts exactly **+1 px on
each of 256 scanlines** (97,072 ink px shipped vs 97,328 fixed).

## Bisection

Hardware bisection closed on an adjacent parent/child pair, 2 reps each:

| commit | blue-sky frames (of 32) | verdict |
|---|---|---|
| `d16cd84` (`7ce2980~1`) | 21 | **PASS 2/2** |
| `7ce2980` — #232 | 0 | **FAIL 2/2** |

`d16cd84` doubles as a proven negative control: this core, rig and ADF do render
the demo. Both fits were clean and the **passing** build had the worse slack, so
this is not a timing artefact — reinforced below by byte-identity.

## Which part of #232?

#232 touches four independent sites. Rather than rebuild per hypothesis, I built
**one** bitstream with a runtime knob selecting which sub-parts are reverted, driven
from two bytes of the Minimig `.cfg`, so every arm ran on the same FPGA image with
no core reload between them.

| reverted | Rampage | verdict |
|---|---|---|
| nothing (shipped #232) | 0/0 | FAIL |
| copper `$E1` blocked cycle | 0/0 | FAIL |
| STRHOR to Denise | 0/0 | FAIL |
| refresh / disk / audio / sprite slot feed | 0/0 | FAIL |
| **`agnus_bitplanedma`** | **7/7 × 2** | **PASS** |

**`rtl/agnus_bitplanedma.v` is necessary and sufficient.** Reverting it restores the
demo with the other three sub-parts still advanced; reverting any of the other three
alone changes nothing.

This also **refutes the prior that pointed at the copper**: WinUAE's changelog
carries *"Reverted b1 copper skip update, it broke Tek/Rampage"*, which made the
copper `$E1` cycle the obvious suspect. On this hardware it is not involved.

**Timing is excluded as a confounder by byte-identity, not by argument.** The
full-revert arm produced frames byte-identical to the clean-timing `d16cd84` build,
and the shipped arm frames byte-identical to `7ce2980`, even though the knob
bitstreams themselves fit at −1.389 / −1.606 ns. Two builds with very different
slack produced bit-for-bit identical output.

## The change

`rtl/agnus_bitplanedma.v` goes back on the raw horizontal counter — the
`hpos_slot` port is dropped and all five references return to `hpos`. The file is
then **byte-identical to its pre-#232 blob** (`58d56b2`), which is checkable with
`git hash-object` rather than by reading the diff. `rtl/agnus.v` loses the one now
dangling port connection. That is the whole patch: 6 insertions, 8 deletions.

I chose the whole-module revert over the smaller alternatives deliberately. Three
narrower variants also fix Rampage and are equally clean on every hardware probe:

| variant | reverts | Rampage | scroll | turret |
|---|---|---|---|---|
| B | only the `ddfrun` odd-timeslot test | 7/7 × 2 | 0 | clean |
| C | that plus the soft DDF window | 7/7 × 2 | 0 | clean |
| E | this PR plus STRHOR | 7/7 × 2 | 0 | clean |

Each of those leaves `agnus_bitplanedma` split across two grids — part on the
advanced slot grid, part on the raw counter — which is a configuration no released
core has ever run. Reverting the whole module restores a state that shipped for
years. **Variant B is measurably kinder to timing** (see below); if you would rather
take the one-expression change, it is a defensible choice and I will happily submit
it instead. I ranked auditability first because this is a regression fix to a merged
commit.

One variant is **not** viable: reverting the soft DDF window *alone*. It quantises
DDF start to 8 CCK instead of OCS's 4, collapsing `$38/$3a/$3c/$3e` onto one x and
putting the dot-cube pan pair 17 lo-res px apart instead of 1. It is only mentioned
because it looks like the obvious minimal fix and is not.

## What this deliberately does *not* revert — and why #232's core claim survives

The copper `$E1` cycle, STRHOR and the refresh/disk/audio/sprite channels stay
advanced. #232's `REFRESH_FIRST_HPOS` argument is untouched by this PR.

More importantly, **#232's turret-jitter improvement is preserved in full**, and the
knob matrix finally attributes it properly. Round 115's knob gated the slot-grid
advance and the DDF window together and could not separate them. This matrix can:

| arm | copper `$E1` + channels | turret excursions |
|---|---|---|
| revert STRHOR + all of `agnus_bitplanedma` | **still advanced** | **0/86 clean** |
| full revert of #232 | **reverted** | **6/89 jitter** |

Those two arms differ *only* in copper `$E1` and the channel feed. So the turret win
comes from **those**, not from `agnus_bitplanedma` and not from STRHOR — and this PR
touches neither. Clean pool 0/306 vs full-revert 6/89, **p = 1.1e-4**.

That is a stronger footing than #232 itself had, and it means fixing Rampage costs
nothing on the jitter that motivated #232 in the first place.

## Two claims in #232's commit message that do not survive checking

I would rather correct these here than leave them in the record.

1. *"A partial application would be worse than no change … roughly 40% of CPU
   bandwidth on every five-bitplane lores title."* **Wrong.** Refresh, disk, audio
   and sprite decoders all end at colour clock ≤ `0x38`, and any normal DDF starts
   at ≥ `0x3C`, so none of them shares the display window with the bitplane fetch.
   Occupied slots stay 5/8 and free slots 3/8 in all configurations.

2. *The turret statistic (11/148 → 0/165, p = 2.156e-4).* The measurement is real and
   reproducible, but the knob behind it could not attribute the improvement to the
   grid advance. See the table above for the attribution that can.

## Mechanism — a candidate, not a claim

WinUAE (cycle-exact A500/OCS/KS1.3) plus an RTL sweep gives a quantified candidate.
With margin = (first fetch CC) − (BPLCON0 write CC + 3), the shipped grid
short-fetches at margin ≤ 0. Shipped has the **least margin of any arm** on the one
tight scene — the chrome logo, 1–4 CCK of slack — and short-fetches on **74%** of
copper-reachable write phases, versus 0% for the fixed arms. That the tight scene is
the logo and not scene 2 matches the corruption starting at t ≈ 58 s.

**I am not claiming this as the cause.** At Rampage's *measured* write position the
shipped build still clears the threshold by 1–2 colour clocks. Closing it means
measuring the BPLCON0 write colour clock in the core rather than in WinUAE — at `$32`
or later it fires, at `$30` or earlier it does not — and I have not run that.

The empirical case does not rest on it: an adjacent-commit bisection, a
single-bitstream attribution, 7/7 × 2 reps per arm, and the independent left-edge
clip that the same change also cures.

## Validation

Rig: DE10-Nano, A500 / OCS / 68000, 1 MB chip + 512 K slow, KS 1.3, 1 floppy, IDE
off — read back from MiSTer's own stdout on every run, not assumed.

All numbers below are from **this patch built as a bitstream**, not from the
attribution knob:

| probe | shipped | **this patch** |
|---|---|---|
| Rampage blue-sky | 0/0 | **7/7, 2 reps** |
| DDF phase bands (15) / phase2 (7), max deviation | 2 / 2 | **0 / 0** |
| dot-cube pan pair | 1 lores | 1 lores |
| preview x | 110 | **112** |
| left-edge clip | **18 px (clipped)** | **20 px, all 22 bands** |
| turret excursions | 0/43 | **0/86** |
| sprite multiplex | 97,072 ink px | 97,328 (+1 px × 256 rows) |

Scroll and sprite probes are 3 frames each and fully deterministic; the scroll
captures are **md5-identical** to those from the knob arms. Config was read back from
MiSTer's stdout on both Rampage reps rather than assumed.

The turret criterion is validated by a positive control in the same session — a fresh
pre-#232 chunk scoring 5/46 against an archived 6/89 (p = 0.51, so the instrument was
discriminating on the day) — and by inert early/late controls that do not move
(p = 1.00). Clean pool 0/399 against pre-#232 11/135, **p = 2.0e-7**.

Two points of rigour worth stating, since both could have hidden a problem:

- **The bitstream tested is the worst-timing of four seeds** (−0.900 ns, failing paths
  on the chip-RAM address path), chosen deliberately. It showed no observable
  misbehaviour on any probe.
- **It reproduces the attribution knob exactly** (turret vs knob arm: Fisher p = 1.00;
  scroll captures byte-identical), so the knob matrix transfers to the real artifact
  rather than merely predicting it.

**Limit of that claim:** the turret and scroll probes exercise 512 K-chip OCS
configurations and Rampage a 1 M + 512 K one. This bounds the timing question
empirically on those paths; it does not prove the chip-RAM address path clean in
general.

## Timing — reported specifically, because the honest answer is two-sided

Measured on Quartus 17.0.2 **Lite** across **16 fits** (4 variants × 4 seeds), one
machine, one qsf. This project's `.qsf` records Standard Edition, so the absolute
numbers are not comparable to your build. The fit is deterministic here — a second,
independently created control worktree reproduced the baseline bit-identically — so
the differences below are real rather than run-to-run jitter.

**On overall worst slack, the patch is indistinguishable from the base.** Baseline
mean −0.401 ns (worst seed −1.148); this patch mean −0.450 ns (worst −0.900). The
*unmodified* base at seed 3 is worse than the patch at any seed. Note also that the
unmodified base **already fails this clock at 3 of 4 seeds**, from
`sdram_state → sd_addr` — a pre-existing location this patch does not create.

**But the patch does move the worst path in Agnus, consistently.** On the isolated
`agnus_beamcounter|hpos[*] → sdram_ctrl|sd_*` metric, the baseline is positive in
all four seeds (min +0.384) and this patch is negative in all four (max −0.106) —
no overlap. Cause is fanout: `agnus_bitplanedma` previously took five of its six
horizontal references from `hpos_slot`, and now takes all of them from `hpos`, while
`hpos_slot` keeps its own loads for the copper, STRHOR and refresh consumers.
Measured `hpos[1..8]` immediate fanout goes 135 → 161, concentrated on the upper bits
the DDF comparators read. Logic depth actually *decreases* (an adder is removed); it
is purely load count.

Variant B moves one reference instead of five and is correspondingly gentler
(mean −0.262 on that metric vs −0.450), which is the one concrete argument for
preferring it.

I am not claiming this is free, and I would rather you saw the specific statement
than a reassuring one: **the patch shifts the worst path in Agnus from the SDRAM
state machine onto the beam counter, and on Lite Edition both the patched and
unpatched designs fail this clock at most seeds.** Please confirm against your own
Standard Edition baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhHnXPREgKzDxyjWf91Y2D
