### PR TITLE
agnus: complete the revert of #232's DMA grid advance - #237 is not fixed, and #239 regressed the copper

### DIFF
--- a/rtl/agnus.v
+++ b/rtl/agnus.v
@@ -335,7 +335,6 @@ agnus_bitplanedma bpd1
 	.dmaena(bplen),
 	.vpos(vpos),
 	.hpos(hpos),
-	.hpos_slot(hpos_slot),
 	.hde(hde),
 	.dma(dma_bpl),
 	.reg_address_in(reg_address),

--- a/rtl/agnus.v
+++ b/rtl/agnus.v
@@ -268,7 +268,7 @@ wire  dma_ref;        //refresh dma slots
 
 agnus_refresh ref1
 (
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.dma(dma_ref)
 );
 
@@ -286,7 +286,7 @@ agnus_diskdma dsk1
 	.dmal(disk_dmal),
 	.dmas(disk_dmas),
 	.speed(floppy_speed),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.wr(wr_dsk),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_dsk),
@@ -308,7 +308,7 @@ agnus_audiodma aud1
 	.dma(dma_aud),
 	.audio_dmal(audio_dmal),
 	.audio_dmas(audio_dmas),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_aud),
 	.data_in(data_in),
@@ -359,7 +359,7 @@ agnus_spritedma spr1
 	.ecs(ecs),
 	.reqdma(req_spr),
 	.ackdma(ack_spr),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.vpos(vpos),
 	.vbl(vbl),
 	.vblend(vblend),
@@ -389,7 +389,6 @@ agnus_copper cp1
 	.blit_busy(blit_busy),
 	.vpos(vpos[7:0]),
 	.hpos(hpos),
-	.hpos_slot(hpos_slot),
 	.data_in(data_in),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_cop),
@@ -439,8 +438,6 @@ agnus_blitter bl1
 //--------------------------------------------------------------------------------------
 
 wire  [8:0] hpos;      //alternative horizontal beam counter
-wire  [7:0] hpos_slot_hi = (hpos[8:1] == htotal[8:1]) ? 8'd0 : hpos[8:1] + 8'd1;
-wire  [8:0] hpos_slot = {hpos_slot_hi, hpos[0]};
 wire [10:0] vpos;      //vertical beam counter
 wire        vbl;       //JB: vertical blanking
 wire        vblend;    //JB: last line of vertical blanking
@@ -482,7 +479,7 @@ agnus_beamcounter  bc1
 //horizontal strobe for Denise
 //in real Amiga Denise's hpos counter seems to be advanced by 4 CCKs in regards to Agnus' one
 //Minimig isn't cycle exact and compensation for different data delay in implemented Denise's video pipeline is required
-assign strhor_denise = hpos_slot==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
+assign strhor_denise = hpos==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
 assign strhor_paula = hpos==(6*2+1) ? 1'b1 : 1'b0; //hack
 
 //--------------------------------------------------------------------------------------

--- a/rtl/agnus_bitplanedma.v
+++ b/rtl/agnus_bitplanedma.v
@@ -38,7 +38,6 @@ module agnus_bitplanedma (
   input  wire           dmaena,           // enable dma input
   input  wire [ 11-1:0] vpos,             // vertical position counter
   input  wire [  9-1:0] hpos,             // agnus internal horizontal position counter (advanced by 4 CCK)
-  input  wire [  9-1:0] hpos_slot,        // dma slot grid index
   output reg            hde,              // video data enable (horizontal)
   output wire           dma,              // true if bitplane dma engine uses it's cycle
   input  wire [  9-1:1] reg_address_in,   // register address inputs
@@ -317,7 +316,7 @@ assign bp_fmode3  = (fmode[1:0] == 2'b11);
 // bitplane dma enable bit delayed by 4 CCKs
 always @ (posedge clk) begin
   if (clk7_en) begin
-    if (hpos_slot[1:0]==2'b11)
+    if (hpos[1:0]==2'b11)
       dmaena_delayed[1:0] <= #1 {dmaena_delayed[0], dmaena};
   end
 end
@@ -337,7 +336,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
+      if (hpos[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
         soft_start <= #1 1'b1;
       else
         soft_start <= #1 1'b0;
@@ -347,7 +346,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
+      if (hpos[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
         soft_stop <= #1 1'b1;
       else
         soft_stop <= #1 1'b0;
@@ -357,7 +356,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'h18)
+      if (hpos[8:1]==8'h18)
         hard_start <= #1 1'b1;
       else
         hard_start <= #1 1'b0;
@@ -367,7 +366,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'hD8)
+      if (hpos[8:1]==8'hD8)
         hard_stop <= #1 1'b1;
       else
         hard_stop <= #1 1'b0;
@@ -423,7 +422,7 @@ assign ddfseq_match = ((!hires && !shres && bp_fmode3)                          
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0]) //cycle alligment
-      if (ddfena && vdiwena && !hpos_slot[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
+      if (ddfena && vdiwena && !hpos[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
         ddfrun <= #1 1'b1;
       else if ((ddfend || !vdiwena) && ddfseq_match) // cleared at the end of last bitplane DMA cycle
         ddfrun <= #1 1'b0;

--- a/rtl/agnus_copper.v
+++ b/rtl/agnus_copper.v
@@ -68,7 +68,6 @@ module agnus_copper
 	input	blit_busy,					// blitter busy flag input
 	input	[7:0] vpos,					// vertical beam counter
 	input	[8:0] hpos,					// horizontal beam counter
-	input	[8:0] hpos_slot,			// dma slot grid index
 	input 	[15:0] data_in,	    		// data bus input
 	input 	[8:1] reg_address_in,		// register address input
 	output 	reg [8:1] reg_address_out,	// register address output
@@ -343,7 +342,7 @@ such a behaviour is caused by dma request pipelining in real Agnus
 always @(posedge clk)
   if (clk7_en) begin
   	if (clk_ena)
-  		if (hpos_slot[8:1]==8'h01)
+  		if (hpos[8:1]==8'h01)
   			bus_blk <= 1; //cycle $E1 is blocked
   		else
   			bus_blk <= 0;


### PR DESCRIPTION
# agnus: complete the revert of #232's DMA grid advance — #237 is not fixed, and #239 regressed the copper

**Draft.** Opened as a draft deliberately: the correctness case is complete and hardware-
validated, but this reverts a merged PR of my own and reintroduces a known jitter
regression, so it should be reviewed before it is treated as ready to land.

## Summary

Two things, the second more serious than the first:

1. **#239 did not fix #237.** Rampage gets past the chrome logo and then freezes at
   t≈120 s.
2. **#239 introduced a new defect.** On the merged tree, **no copper list can do timed
   work anywhere inside the display fetch window.** This is measured on hardware, below.
   It affects far more titles than #237 does.
3. **The revert is also the more accurate configuration.** Refresh denial holes measured on
   the rig: this PR **4, 6, 8, 10** = WinUAE; shipping `eaeaf09` **3, 5, 7, 9**, one colour
   clock early. #232 and #234 landed a day apart and correct the *same* colour clock, so the
   core has been double-corrected since 2026-08-28. Details below.

Issue #237 should be reopened. If the timing case for this revert needs more review,
consider reverting #239 and #232 as an immediate mitigation regardless of what happens to
this PR, because point 2 is a live regression in the current `MiSTer` branch.

## #239 did not fix #237

I opened #239 and it was merged as `eaeaf09`. It is a partial fix.

#239 gets Rampage past the chrome-logo corruption at t≈58 s, which is what the PASS
criterion of the day tested. It then **freezes at t≈120 s** and never recovers. That was
visible in the very timeline quoted in the #239 PR body and I did not check it against a
control. My fault, and this PR is the correction.

The freeze is confirmed on the physical monitor, not only in capture tooling: the frozen
frame was photographed off the screen and matches the captured frame feature for feature.

| build | samples | distinct frames | distinct frames at t ≥ 425 s | longest byte-identical span |
|---|---|---|---|---|
| `eaeaf09` (merged #239) | 138 | 29 | **3 / 47** | **355 s** |
| pre-#232 `d16cd84` (control) | 242 | 235 | 154 / 154 | 5 s |

The frozen frame has **2 colours**; the same instant rendered correctly has 10. It is the
demo's inter-part interlude with bitplanes missing, held indefinitely.

Not a disk swap: there is one ADF, it contains no INSERT/SWAP/TURN/PART strings, and
MiSTer's read counters are flat (`d_rchar=0, d_syscr=0`) across 40 consecutive seconds of
the frozen window. The Amiga is not asking for a disk.

## The real PASS criterion

The old criterion — "≥1 frame in t = 80–130 s with mean B > mean R" — only ever tested
getting past the chrome logo, which is how #239 shipped on a demo that does not run.

Ground truth from WinUAE 6.0.3 cycle-exact A500/OCS, matched to the MiSTer config:
the demo is **~412 s of main body in 13 parts**, a fade to black at 395–397 s, a reload,
then an **endless end-credits scroller** from ~418 s that never loops and never
terminates. The longest byte-identical stretch anywhere in the 929 s reference is **6 s**.

- **Primary:** reach the credits scroller by t ≈ 420 s and still be producing distinct
  frames at t = 600 s.
- **Fail-fast, ~2 minutes:** the interlude at t ≈ 114–120 s holds byte-identical for at
  most ~5 s and has **more than 2 colours**; part 3 is running by t ≈ 125 s.

## What this PR does

Reverts the remainder of #232 (`7ce2980`), leaving `agnus.v` identical to `d16cd84`.

#232 added a `hpos_slot` wire that advances the DMA slot decode by one colour clock and
routed it to four sites: the copper `$E1` blocked cycle, the whole port into
`agnus_bitplanedma`, `strhor_denise`, and the refresh/disk/audio/sprite channels. #239
reverted only the `agnus_bitplanedma` port.

## Why a partial revert cannot work

Every one of the eight site combinations was measured on hardware, on a single bitstream
with a runtime knob, with in-session controls each time:

| left advanced | outcome |
|---|---|
| nothing (full revert) | **runs the demo** |
| STRHOR only | **runs the demo** |
| copper only | original #232 logo bug returns |
| channels only | logo bitplanes shredded |
| copper + STRHOR | original #232 logo bug returns |
| channels + STRHOR | logo bitplanes shredded |
| copper + channels + STRHOR (= #239) | **freezes at t≈120 s** |
| all four (= #232) | original #232 logo bug |

The knob was validated against the commits before anything was concluded from it: a
full-`agnus` slot map with no stubs reproduces `7ce2980`, `eaeaf09` and `d16cd84`
byte-identically, zero differing cells over 227×18.

## The regression: on `eaeaf09` the copper is shut out of the whole fetch window

This is the part that should decide the PR, and it is a direct measurement rather than an
inference from the Rampage symptom.

A copper list with a mid-DDF `WAIT` on a horizontal position writing `COLOR00`, swept over
eight positions. Group A is the real case (BPU=4, bitplane DMA on). Group B is the control
on the *same arm and same bitstream* with BPU=0, where nothing competes for the bus.

| `WAIT` at HP | `$50` | `$60` | `$70` | `$80` | `$90` | `$A0` | `$B0` | `$C0` | fit |
|---|---|---|---|---|---|---|---|---|---|
| pre-#232 | 35 | 67 | 99 | 131 | 163 | 195 | 227 | 259 | `x = 2·HP − 125`, residual 0.00 |
| **`eaeaf09`** | **297** | **297** | **297** | **297** | **297** | **297** | **297** | **297** | **slope 0.0000** |
| `eaeaf09`, BPU=0 | 33 | 65 | 97 | 129 | 161 | 193 | 225 | 257 | clean staircase |

**The requested position has no effect at all.** Every mid-DDF copper write lands at the
same place — x = 297, which through the arm's own BPU=0 calibration is colour clock 212.
DDFSTOP is `$C8` = 200 and the last fetch block ends at 207, so the copper is served at the
first opportunity *after the final bitplane fetch of the line* and is blocked everywhere
before it.

The BPU=0 row is what rules out the boring explanations: same build, same probe, same
capture path, clean staircase. The only difference is whether bitplane DMA is running. Zero
spread within every band (min == max over all 24 rows), 3 byte-identical shots per arm.

Mid-line colour splits, raster bars, copper gradients, per-line bitplane-pointer or scroll
reprogramming — the ordinary uses of a copper list — cannot work inside DDF on the current
`MiSTer` branch.

I want to be explicit that this was not caught by the existing probe suite, and why: the
scroll-phase, sprite-multiplexing and jitter instruments all measured `eaeaf09` **clean**.
None of them runs a copper list that has to act mid-DDF. The instruments were healthy; the
coverage was not.

## Mechanism

`agnus_copper.v` does not decode a slot. It runs a free-running `bus_ena` toggle
resynchronised once per line by `bus_blk`. **227 is odd**, so moving that compare by one
colour clock does not shift the copper by one cycle — it **inverts the copper's bus parity
for the whole line**. Two invariants follow:

- **I1** copper parity must differ from bitplane-fetch parity;
- **I2** copper parity must differ from refresh/disk/audio/sprite parity.

Which accounts for all three failure modes:

- **#239 violates I1.** Every bitplane fetch lands on a copper cycle: **33 copper grants
  per line against pre-#232's 113, and none at all between `hi` 62 and `hi` 220.** This is
  the simulation prediction that the hardware `WAIT` sweep above confirmed — predicted
  "served only after `hi` ≈ 220", measured colour clock 212.
- **Channels-advanced violates I2.** 27 cycles per line stolen (refresh 4, disk 3,
  audio 4, sprite 16), 113 → 86 grants.

**And Rampage contains exactly the list that predicts.** Disassembling the copper lists out
of the demo's own chip RAM, the list running during the t ≈ 120 s interlude — the moment
`eaeaf09` freezes — carries **8 `WAIT`+`MOVE` pairs at HP 44/60/81/98, three of them inside
DDF (48–216)**. A list that must *act* mid-DDF is precisely what #239 shuts out. That is
independent corroboration of the regression, from the failing program itself.

**What I cannot give you is the mechanism for #232's own chrome-logo failure, and I would
rather say so than offer my best surviving guess.** An earlier revision of this PR explained
it as a lost colour clock of BPLCON0 register-setup margin; **that was a harness artefact and
is withdrawn** (details below). Since then I have eliminated, by measurement: chipset
internals (0 mismatching ticks over a full frame on 15 signals), Denise/display phase (a
compensating build landed byte-identical on hardware and still failed), CPU bus phase (34,546
events, structurally locked), copper cost (114 grants/line, identical), blitter throughput
(0.008 raster lines against a 10-line-sensitive instrument), blitter channel identity
(0/11,968 grants, 0/5,984 destination words), the post-BBUSY final-D window (~20× margin, and
symmetric between the trees), the copper's `bus_ena` parity anchor (0/70,512 grants — and the
logo scene's copper list **terminates at line 32**, taking zero bus slots for the rest of the
frame), `strhor_paula` (0/624) and the `hde`/DIW pipeline (0/1,248 edges).

So the parity story above accounts for #239 and for the channels arm. It does not account for
#232 as merged. **This PR does not rest on a mechanism** — it rests on the built artefact
passing at its worst-timing seed, on a hardware-confirmed regression in what ships today, and
on a hardware-confirmed accuracy comparison. I think that is the right basis to act on, and I
would rather leave the mechanism open than close it with a story I cannot measure.

## The cost, stated plainly

**This reintroduces the sprite/turret jitter that #232 was written to fix.** It is not a
free revert and I am not going to present it as one.

Measured on the Hybris turret instrument, unmodified scorer:

| arm | excursions / settled | rate |
|---|---|---|
| full revert (this PR) | 14 / 179 | 7.82 % |
| #232 advanced | 0 / 132 | 0 % |

Fisher exact, full revert vs the clean pool (0/531): **p = 1.1e-6**. The improvement #232
delivered was real.

The judgement here is that a demo that runs with occasional one-scanline sprite jitter
beats a demo that freezes, and that a correctness regression affecting rendering should not
be traded for a jitter improvement. But the jitter is a genuine open bug and should be
re-derived rather than re-reverted, and there is now a concrete lead — below.

### Where the jitter benefit actually came from, measured

All eight site combinations were measured on the turret. The result narrows to one site:

| contrast | result | Fisher |
|---|---|---|
| copper `$E1` **advanced** (0/88, 0/87) vs **reverted** (7/90) | copper flips it | **0.0139** |
| refresh/disk/audio/sprite channels advanced (0/176) vs reverted (0/88, 0/87) | channels do **nothing** | **1.00** |

Across ten arms, jitter appears **iff the copper `$E1` compare is reverted**. Advancing the
DMA channels — the sites #232's accuracy argument was actually about — changes nothing
measurable at all.

That matters for interpreting #232: the copper's `$E1` blocked cycle asserts **DBR, which
blocks the CPU as well as the blitter**, so advancing it shifts *when the CPU gets the bus*.
The jitter improvement was a CPU-arrival side effect, not a consequence of more accurate DMA
slot placement.

### The actual root cause, measured against WinUAE

Hybris polls the beam with `MOVE.L ($DFF004).L,D1` — word 1 reads VPOSR (V8), word 2 reads
VHPOSR (V[7:0]). At the vpos 255→256 wrap this can straddle the moment `vpos` increments.
Measured in the same architectural frame on both sides:

| | word 1 | word 2 | composed | margin to the flip |
|---|---|---|---|---|
| WinUAE | reported H = 225 | reported H = **1** | `$8000FF01` → `$0FF00` | **+1 CCK** (last cycle still reporting old V) |
| Minimig | reported H = 226 | reported H = **2** | `$00000000` | **−1 CCK** (lands *on* the flip) |

Minimig composes a false "vpos < 40" and arms the sprite one line late.

**The flip position itself is not the bug.** Minimig's reported V changes at reported H = 2,
*exactly as WinUAE's does* — a read at reported H = 1 returns the old V in both, with 1,752
and 1,850 witnesses across two independent Minimig captures. Nor is it the CPU long-access
word separation: WinUAE is 98.8 % at 2 CCK and Minimig is **97.08 % at 2 CCK**, the same
distribution with the same wrap-contention stretch.

**The difference is that Minimig's CPU-visible chipset grid sits one architectural colour
clock later than WinUAE's:**

| | refresh denial holes (reported H with zero CPU reads) |
|---|---|
| WinUAE | 4, 6, 8, 10 |
| Minimig | **5, 7, 9, 11** |

And decisively, **reported H = 226 (`$E2`)**: chipset-owned in WinUAE — 1 CPU beam read in
2,016,728, because the copper takes that slot every line — but **free to the CPU in Minimig**
(1,993 reads with the copper on). That is exactly where Hybris's word 1 lands, and from
there the contention stretch puts word 2 on the flip.

## The accuracy argument, measured on hardware: this revert is strictly closer to the reference than what ships today

An earlier revision of this PR said #232 moved refresh *away* from WinUAE's reference. **That
was my error and I withdraw it.** It came from applying #234's −1 readback correction to
Minimig's internal slot numbers, when that −1 is already inside the frame in which the denial
holes above were measured — I double-counted it. In the software-observable frame Minimig's
grid really is one colour clock late, and #232 was correct about the direction. That is why
it suppressed the turret jitter.

**What has changed since is that the reference comparison has now actually been made, on
hardware, on the builds that matter — and it favours this revert.** #232 landed 2026-08-27.
#234 (`06f30af`, *"agnus: VHPOSR reads one colour clock high"*) landed 2026-08-28, **one day
later**, and corrects the *same* colour clock through the readback path. Either fix alone lands
on the reference. The core currently ships both.

Measured with a guest-side probe — a 68000 loop reading `VHPOSR` with `DMACON` cleared so
refresh is the only bus owner, binning reported H over 2,000,000 samples, core identity md5-
verified on the rig for every run:

| build | refresh denial holes, reported H | |
|---|---|---|
| `d16cd84` (pre-#232, pre-#234) | 5, 7, 9, 11 | one CCK **late** |
| **this PR** (`7a19f08`: revert #232, keep #234) | **4, 6, 8, 10** | **matches** |
| shipping today (`eaeaf09` = #232 + #239 + #234) | 3, 5, 7, 9 | one CCK **early** |
| WinUAE | 4, 6, 8, 10 | — |

Every one of those was predicted from simulation first and then held on hardware. The three
histograms are the same histogram rigidly relabelled — `SHIP[i]` against `REV[i+1]` mismatches
in **one bin out of 239**, the line wrap.

I should also correct something in this repo's own record while I am here. The figure that made
#232 look necessary — *"Minimig's refresh sits at reported H 5,7,9,11 against WinUAE's
4,6,8,10"* — is a **correct measurement of a tree that is neither of the builds in question**.
It was captured on a branch based on `809b9558` (#215, 2026-07-26), i.e. pre-#232 *and*
pre-#234. Before this week no reported-H histogram had ever been taken on the shipping core.

**Scoping that claim honestly, because there is a second axis and this PR does not win it
outright.** The denial holes are one observable; the other is *where the vertical counter flips
in the reported frame*. WinUAE flips at reported H = 2. In simulation this PR flips at H = **1**,
and so does the shipping core; `7ce2980` and `d16cd84` flip at H = 2. So on the holes this PR
matches and shipping does not, and on the flip neither matches — meaning **this PR is strictly
more accurate than what ships today, on both axes taken together, but it is not exactly the
reference.** I would rather state that than round it up.

I have a one-line read-path change to `agnus_beamcounter.v` that moves the flip to H = 2 while
leaving the DMA slot map bit-identical, which would put the tree on the reference for both. It
is not in this PR — it is the jitter candidate discussed below and it has not been tested on
hardware yet.

**So this PR is not an accuracy sacrifice made to fix Rampage.**

What #232 got wrong was the mechanism, not the goal. `agnus_copper.v` runs a free-running
`bus_ena` toggle resynchronised once per line by `bus_blk`, and because PAL lines are 227 CCK
— odd — moving that compare inverts copper bus parity for the whole line rather than shifting
it by a cycle. That inversion is what starves the copper and forces the bitplane advance that
breaks Rampage.

## Where the jitter fix has to come from, and why it is not in this PR

Not from the beam counter and not from the CPU bridge — both were candidates and both are
refuted above. And it can no longer come from advancing the CPU-visible grid: **with #234 in
the tree that grid is already correct**, so a further advance is an over-correction, which is
precisely what the shipping core is. An earlier revision of this section proposed exactly that
and I withdraw it.

What the turret attribution does still say is where the *sensitivity* lives: jitter appears iff
the copper `$E1` compare is reverted, and the copper's blocked cycle asserts DBR, which gates
when the CPU gets the bus. So the mechanism is about **when the CPU is served relative to the
`vpos` flip**, not about the reported grid — and #234 shifts the readback, not the timing, so
the CPU's *physical* arrival relative to the flip still differs by a colour clock between the
two grids even where the reported frames agree. That is the seam a real fix has to close.

**The obvious way to have both — advance the grid but leave the copper's parity alone — does
not exist, and that is now settled rather than suspected.** `agnus_copper.v` computes
`reqdma = dma_req & bus_ena & clk_ena`, which is *not* gated by `bus_blk`, and
`reqdma → dma_cop → dbr = 1` is the CPU denial. So the CPU-visible denial set is
`{hi : bus_ena == 1}` = `{0} ∪ {3, 5, …, 225}` — 113 cycles, matching the measured 113
grants per line, and a **period-2 set**. Shifting a period-2 set by one *is* inverting it.
Advancing the CPU-visible grid and inverting the copper's bus parity are the same operation,
so there is no variant that does one without the other. #232 does both, consistently, at all
seven sites — and it still fails Rampage on hardware.

I should also withdraw something. An earlier revision of this PR explained #232's chrome-logo
failure as a lost colour clock of BPLCON0 register-setup margin. **That was a harness
artefact and I retract it.** The sweep injected the write at an *absolute* colour clock, so it
could not see that the copper's own grants move with the fetch. Re-run with a real
copper-placed write — genuine list `WAIT VP=$61,HP=T` / `MOVE #$6200,BPLCON0`, real `agnus`
under simulation — the last safe WAIT `T` is **26 in all four arms**, the failure boundary is
`T=27` in all four, and the grant-to-fetch gap is 3 CCK in all four. #232 costs no
register-setup margin at a copper-sourced write.

The hardware failure is real and measured; only my explanation of it collapsed. What survives
is a correlation: every arm that fails has its first bitplane fetch at `hi` 61, every arm that
passes has 62 or 63, 8/8. That points at something positional in Denise's phase — which is
also what produces the 2-lo-res-pixel left-edge shift #232 shipped with — but it is not yet a
mechanism, and I am not going to dress it up as one.

**So: this PR restores correctness. It does not restore the jitter improvement, and I do not
currently have a change that does both.** I would rather say that plainly than ship a second
guess on top of the first one.

### A lead, offered as a lead and not as a fix

Having run out of mechanisms on the Minimig side, I had an independent reviewer with no
knowledge of the above compare WinUAE's source against `rtl/` and tell me where the two
implementations differ *structurally*. Two things came back that I think are worth recording
here, because if either holds it means the turret does not need the grid moved at all.

**1. WinUAE decouples beam *readback* from the raw counter; we do not.** `VPOSR()`
(`custom.cpp:2390`) and `VHPOSR()` (`:2510`) both fetch the position and then call `incpos()`
(`:2356`), which advances `vp` when `hp == 1` and then increments and wraps `hp` — so the
guest-visible beam is not simply the raw counter. Note `incpos` takes **pointers to local
copies**: it advances no emulator state and is purely a readback transform. Line numbers are
against upstream `683311be`. `agnus_beamcounter.v:104` returns
`{vpos[7:0], hpos[8:1]}` straight out (with #234's `−1` at `:109`) while the vertical
increment itself is triggered at `hpos == 2` (`:286-291`). Hybris's symptom is exactly a
`MOVE.L $DFF004` whose two word reads straddle the `vpos` increment. **A change confined to
readback moves no DMA slot** — which is the shape this problem has needed all along, and which
this PR would not conflict with.

**2. The grid advance is not the rigid shift I have been treating it as.** `7ce2980` routes
`hpos_slot` to the five DMA channels, the copper's `bus_blk` and `strhor_denise` — but not to
the blitter, which has only `.clkena(cck)` and no `hpos` input (`agnus.v:417`), while its
availability `enadma(blten & ena_blt)` comes from the *shifted* blockers (`agnus.v:261`). So
the advance moves the phase of "not available to the blitter" relative to the blitter's own
FSM: total throughput preserved, but not necessarily the same channel at the raster-critical
point. That is consistent with what Rampage does, and it is a thing my earlier blitter
measurement did not test — I compared fill *completion line* (identical in 16/16) and never
per-cycle channel identity. WinUAE has no equivalent asymmetry because the blitter arbitrates
through the same central RGA slot as everything else (`blitter.cpp:1741`).

**Since writing that, both have been tested in simulation. The second is dead** — blitter
grant sequence `(state, chsel, address, we)` is identical in 0/11,968 across all four trees,
final memory image 0/5,984 words, holding under hires 4-plane pressure and a saturated CPU. So
is the post-BBUSY window as a #237 explanation: it measures 2 CCK against a hazard that needs
>35, a ~20x margin, symmetric between the trees. (Minimig does genuinely lack WinUAE's guard
there, and I will send that as its own small PR on its own merits.)

**The first survived, and turned into something more useful than a lead.** `incpos` is best
read as *"the beam as of the end of the CPU's bus cycle"* — WinUAE's `dma_cycle()` never runs
`do_cck()` for the cycle the CPU itself consumes, so its counter is stale by exactly one CCK at
handler time and `incpos` replays that one cycle. **Minimig has no equivalent staleness** — the
CPU latches a chip read exactly 1 CCK after the slot it was granted in, 251,728/251,728 events,
all four trees — so porting `incpos` literally would be wrong, and porting it naively into the
latch frame would introduce a one-cycle *early* error. What is correct here is the one-line
delay of the **`vpos` read path only**, which lands on the same guest-visible beam by the route
this design actually needs.

That change reproduces `7ce2980`'s guest-visible beam exactly while leaving the DMA slot map
**bit-identical** — 5,448 CCK samples, all 26 arbitration fields (`dbr`, `dbs`, `chan`,
`bus_ena`, `bus_blk`, copper state, `ir1`/`ir2`, …) with zero differences, copper grants
113–114/line unchanged, CPU grant positions bit-identical. **If it also suppresses the jitter on
hardware, it and this PR together fix both bugs with no grid movement at all.** A timing sweep
is running; the hardware test comes after. I am not putting it in this PR until it is measured,
and I will say plainly that the published mechanism for the jitter — a false `$00000000`
composition — is **not** supported by these runs: the polarity flips with DMA load and in one
configuration it is the *clean* trees that compose the false value.

## Validation — on the built bitstream, at its worst-timing seed

Everything below is measured on the actual `.rbf`, not on the runtime knob used to explore
the matrix, and deliberately on **seed 3 — the worst-timing of the four seeds** (−0.292 ns),
so the timing question is bounded by a measurement rather than an argument. Config quoted
from MiSTer's own stdout on every run (`68000, OCS-A500, ChipRAM 1M, SlowRAM 512K`), core
identity confirmed from `ps w` argv.

**Rampage: PASS, both reps**, 265 samples each over t = 5…656 s.

| criterion | target | rep 1 | rep 2 |
|---|---|---|---|
| interlude byte-identical span | ≤ ~5 s | 3 s | 1 s |
| interlude colours | > 2 | 3–4 | 3–4 |
| part 3 running | by t ≈ 125 s | ncol 10 @ 124 | ncol 10 @ 125 |
| **credits scroller** | by t ≈ 420 s | **t = 421** | **t = 421** |
| distinct frames at t = 600 s | yes | 13/13 | 13/13 |
| longest still, whole run | ref is 6 s | 5 s | 5 s |

**Copper `WAIT` sweep: clean staircase**, `x = 2.0000·HP − 125.00`, max residual **0.00 px**,
groups A and B identical. The regression is gone from the built artifact.

**`ddfprobe-phase` / `-phase2` / `-sprmulti`:** max dev **0**, 97,328 ink px — all on target.

**Knob-to-build transfer, which is the result that could have invalidated the matrix:** no
divergence anywhere. Three of the four suites are **md5-identical** to the corresponding
knob captures, and the turret is statistically indistinguishable from pre-#232 (p = 0.83).

## Timing

4 seeds per variant with the unmodified control swept alongside, since single-seed
comparisons on this tree are worthless — placement noise is 0.6–1.3 ns.

| | mean worst slack | isolated `hpos[*] → sd_*` | failing paths in `agnus_beamcounter` |
|---|---|---|---|
| `eaeaf09` (control) | −0.450 | negative **4/4**, worst −0.900 | up to 2774 |
| **this PR** | **−0.190** | **positive 4/4**, min +0.364 | **zero, every seed** |

The critical path moves back off the beam counter onto the SDRAM state machine, where it sat
before #232, and the isolated column lands on top of the historical pre-#232 baseline.

Worth noting because it corrects an earlier theory of mine: `hpos` immediate fanout *rises*
(161 → 261) and timing still improves sharply. The mechanism is **depth, not fanout** —
`hpos_slot` put an adder plus a wrap mux in front of the comparators.

Fixes #237 (which should be reopened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhHnXPREgKzDxyjWf91Y2D
