### PR TITLE
agnus: fix Hybris beam polling without regressing TEK Rampage

### DIFF
--- a/rtl/agnus.v
+++ b/rtl/agnus.v
@@ -268,7 +268,7 @@ wire  dma_ref;        //refresh dma slots
 
 agnus_refresh ref1
 (
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.dma(dma_ref)
 );
 
@@ -286,7 +286,7 @@ agnus_diskdma dsk1
 	.dmal(disk_dmal),
 	.dmas(disk_dmas),
 	.speed(floppy_speed),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.wr(wr_dsk),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_dsk),
@@ -308,7 +308,7 @@ agnus_audiodma aud1
 	.dma(dma_aud),
 	.audio_dmal(audio_dmal),
 	.audio_dmas(audio_dmas),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_aud),
 	.data_in(data_in),
@@ -335,7 +335,6 @@ agnus_bitplanedma bpd1
 	.dmaena(bplen),
 	.vpos(vpos),
 	.hpos(hpos),
-	.hpos_slot(hpos_slot),
 	.hde(hde),
 	.dma(dma_bpl),
 	.reg_address_in(reg_address),
@@ -360,7 +359,7 @@ agnus_spritedma spr1
 	.ecs(ecs),
 	.reqdma(req_spr),
 	.ackdma(ack_spr),
-	.hpos(hpos_slot),
+	.hpos(hpos),
 	.vpos(vpos),
 	.vbl(vbl),
 	.vblend(vblend),
@@ -390,7 +389,6 @@ agnus_copper cp1
 	.blit_busy(blit_busy),
 	.vpos(vpos[7:0]),
 	.hpos(hpos),
-	.hpos_slot(hpos_slot),
 	.data_in(data_in),
 	.reg_address_in(reg_address),
 	.reg_address_out(reg_address_cop),
@@ -440,8 +438,6 @@ agnus_blitter bl1
 //--------------------------------------------------------------------------------------
 
 wire  [8:0] hpos;      //alternative horizontal beam counter
-wire  [7:0] hpos_slot_hi = (hpos[8:1] == htotal[8:1]) ? 8'd0 : hpos[8:1] + 8'd1;
-wire  [8:0] hpos_slot = {hpos_slot_hi, hpos[0]};
 wire [10:0] vpos;      //vertical beam counter
 wire        vbl;       //JB: vertical blanking
 wire        vblend;    //JB: last line of vertical blanking
@@ -483,7 +479,7 @@ agnus_beamcounter  bc1
 //horizontal strobe for Denise
 //in real Amiga Denise's hpos counter seems to be advanced by 4 CCKs in regards to Agnus' one
 //Minimig isn't cycle exact and compensation for different data delay in implemented Denise's video pipeline is required
-assign strhor_denise = hpos_slot==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
+assign strhor_denise = hpos==(6*2-1) && (vpos > 8 || ecs) ? 1'b1 : 1'b0;
 assign strhor_paula = hpos==(6*2+1) ? 1'b1 : 1'b0; //hack
 
 //--------------------------------------------------------------------------------------

--- a/rtl/agnus_beamcounter.v
+++ b/rtl/agnus_beamcounter.v
@@ -101,12 +101,21 @@ parameter VBSTOP_NTSC_VAL = 9'd20;           // vertical blanking end (PAL 26 li
 
 //--------------------------------------------------------------------------------------
 
+reg [10:0] vpos_rb;
+reg [10:0] vpos_d1;
+always @(posedge clk) begin
+	if (clk7_en) begin
+		vpos_d1 <= vpos;
+		vpos_rb <= vpos_d1;
+	end
+end
+
 //beamcounter read registers VPOSR and VHPOSR
 always @(*) begin
 	if (reg_address_in[8:1]==VPOSR[8:1] || reg_address_in[8:1]==VPOSW[8:1])
-		data_out[15:0] = {long_frame,1'b0,ecs,ntsc,2'b00,{2{aga}},long_line,4'b0000,vpos[10:8]};
+		data_out[15:0] = {long_frame,1'b0,ecs,ntsc,2'b00,{2{aga}},long_line,4'b0000,vpos_rb[10:8]};
 	else if (reg_address_in[8:1]==VHPOSR[8:1] || reg_address_in[8:1]==VHPOSW[8:1])
-		data_out[15:0] = {vpos[7:0],|hpos[8:1] ? hpos[8:1] - 8'd1 : ersy ? 8'd0 : htotal[8:1]};
+		data_out[15:0] = {vpos_rb[7:0],|hpos[8:1] ? hpos[8:1] - 8'd1 : ersy ? 8'd0 : htotal[8:1]};
 	else
 		data_out[15:0] = 0;
 end

--- a/rtl/agnus_bitplanedma.v
+++ b/rtl/agnus_bitplanedma.v
@@ -38,7 +38,6 @@ module agnus_bitplanedma (
   input  wire           dmaena,           // enable dma input
   input  wire [ 11-1:0] vpos,             // vertical position counter
   input  wire [  9-1:0] hpos,             // agnus internal horizontal position counter (advanced by 4 CCK)
-  input  wire [  9-1:0] hpos_slot,        // dma slot grid index
   output reg            hde,              // video data enable (horizontal)
   output wire           dma,              // true if bitplane dma engine uses it's cycle
   input  wire [  9-1:1] reg_address_in,   // register address inputs
@@ -317,7 +316,7 @@ assign bp_fmode3  = (fmode[1:0] == 2'b11);
 // bitplane dma enable bit delayed by 4 CCKs
 always @ (posedge clk) begin
   if (clk7_en) begin
-    if (hpos_slot[1:0]==2'b11)
+    if (hpos[1:0]==2'b11)
       dmaena_delayed[1:0] <= #1 {dmaena_delayed[0], dmaena};
   end
 end
@@ -337,7 +336,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
+      if (hpos[8:1]=={ddfstrt[8:3], ddfstrt[2] & ecs, 1'b0})
         soft_start <= #1 1'b1;
       else
         soft_start <= #1 1'b0;
@@ -347,7 +346,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
+      if (hpos[8:1] == {ddfstop[8:3], ddfstop[2] & ecs, 1'b0})
         soft_stop <= #1 1'b1;
       else
         soft_stop <= #1 1'b0;
@@ -357,7 +356,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'h18)
+      if (hpos[8:1]==8'h18)
         hard_start <= #1 1'b1;
       else
         hard_start <= #1 1'b0;
@@ -367,7 +366,7 @@ end
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0])
-      if (hpos_slot[8:1]==8'hD8)
+      if (hpos[8:1]==8'hD8)
         hard_stop <= #1 1'b1;
       else
         hard_stop <= #1 1'b0;
@@ -423,7 +422,7 @@ assign ddfseq_match = ((!hires && !shres && bp_fmode3)                          
 always @ (posedge clk) begin
   if (clk7_en) begin
     if (hpos[0]) //cycle alligment
-      if (ddfena && vdiwena && !hpos_slot[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
+      if (ddfena && vdiwena && !hpos[1] && dmaena_delayed[0]) // bitplane DMA starts at odd timeslot
         ddfrun <= #1 1'b1;
       else if ((ddfend || !vdiwena) && ddfseq_match) // cleared at the end of last bitplane DMA cycle
         ddfrun <= #1 1'b0;

--- a/rtl/agnus_copper.v
+++ b/rtl/agnus_copper.v
@@ -68,7 +68,6 @@ module agnus_copper
 	input	blit_busy,					// blitter busy flag input
 	input	[7:0] vpos,					// vertical beam counter
 	input	[8:0] hpos,					// horizontal beam counter
-	input	[8:0] hpos_slot,			// dma slot grid index
 	input 	[15:0] data_in,	    		// data bus input
 	input 	[8:1] reg_address_in,		// register address input
 	output 	reg [8:1] reg_address_out,	// register address output
@@ -343,7 +342,7 @@ such a behaviour is caused by dma request pipelining in real Agnus
 always @(posedge clk)
   if (clk7_en) begin
   	if (clk_ena)
-  		if (hpos_slot[8:1]==8'h01)
+  		if (hpos[8:1]==8'h01)
   			bus_blk <= 1; //cycle $E1 is blocked
   		else
   			bus_blk <= 0;


### PR DESCRIPTION
## Summary

Replacement for closed draft #241, now based on the current `MiSTer` branch
(`d760626`, Release 20260907). This combines the Rampage-compatible DMA
scheduling with the Hybris beam-polling fix. Kept as a draft for review.

1. Completely revert #232's one-colour-clock DMA-grid advance, including
   bitplane timing, copper blocking and the Denise horizontal strobe.
2. Delay only the vertical bits returned by VPOSR/VHPOSR by two `clk7_en`
   samples (one colour clock), including their existing write-address aliases.

The internal raster counters and restored DMA schedule are not delayed.
The horizontal readback correction from #234 remains. There is no blitter
change, title-specific detection, tracing RTL, or userspace change.

## Why Both Changes

The complete DMA-grid revert restores the behavior needed by TEK Rampage,
but alone reintroduces Hybris's cannon jitter. Hybris polls using `MOVE.L
$DFF004,D1`: if the two word reads straddle the vertical 255/256 transition,
they can combine into zero and falsely leave the polling loop. Separating
vertical readback timing from DMA scheduling fixes the tested polling cases
without reinstating the Rampage regression.

WinUAE's `custom.cpp` at `683311be` was used to compare `incpos`, VPOSR/VHPOSR,
CPU sampling and copper reservation/transfer timing. This is not a literal
port of `incpos`, which also accounts for emulator CPU cycles. Reducing the
copper WAIT pipeline was tested and rejected; it did not fix the polling bug.

## Validation On Current Upstream

Fresh builds/tests use head `2764b51` on `d760626`, not the obsolete #241 base.
The functional source also matches the previously hardware-accepted candidate.

| CPU-in-loop test | Revert-only control | Combined fix |
| --- | --- | --- |
| 36 entry phases, active bitplanes | 7 false exits | 0 false exits |
| 15 phases, audio/disk request contention | 3 false exits | 0 false exits |

The local harness executes the actual four-instruction Hybris polling loop
on fx68k with the bridge, Gary, Agnus and final copper WAIT pair. It compiles
from fresh production checkouts with explicit simulation-only declaration
hoisting and a known clocked-copper assignment race correction applied equally
to both arms. It checks completion, CPU-latched read values, known copper
addresses and 480 bitplane slots per run; the contention profile also checks
24 audio and 18 disk slots. Initial runs missing the race correction were
discarded as invalid. This is a focused regression, not full-game emulation.

Fresh Quartus 17.0.2 seed-4 build: zero errors, 81 warnings; minimum reported
slack +0.398 ns setup, +0.247 ns hold, +3.716 ns recovery, +0.766 ns removal,
+1.101 ns pulse width. The report retains incomplete setup/hold-constraint
warnings; this is not a claim that all paths are constrained.

Fresh Rampage hardware run on DE10-Nano: PASS. Four named checkpoints at
82/130/420/610 seconds show shaded chrome, subsequent geometry, credits, and
continued plasma/scroller progress. Exactly four captures, no polling; all
four decoded frames are distinct. Stock MiSTer userspace and existing
profiles were preserved; the rig was parked at MENU afterward.

Test artifact: `Mg237MainS4.rbf`, 3,584,660 bytes, SHA256
`1bd2b8a8ee49b03858c2c16d0a177919335051cf8dc7bb5c246f586b93c2093c`.

Earlier source-equivalent hardware candidate: the user confirmed no Hybris
cannon jitter. Rampage rendered its blue chrome scene correctly, reached
credits and continued through 610 seconds. That earlier Hybris observation is
not presented as a new manual test of the freshly compiled bitstream.

Coverage is targeted PAL/OCS, not exhaustive chipset/game compatibility.
Seed 4 is deliberate: earlier seed sweeps included timing failures, so this
does not claim timing closure for arbitrary/default-seed rebuilds.

Related: #237, #232, #234, #239, #241.
